### PR TITLE
Update raylib and remove deprecated syntax

### DIFF
--- a/game/systems/init.nelua
+++ b/game/systems/init.nelua
@@ -187,7 +187,7 @@ global GearControllerSystem = @MakeSystem(GearControllerRunner, false, true, fal
 
 global EngageRunner = @record{}
 
-function EngageRunner:run(collisions: *Collisions, gear_slot: *GearSlot, system_data: SystemData*)
+function EngageRunner:run(collisions: *Collisions, gear_slot: *GearSlot, system_data: *SystemData)
    for i = 0, < #collisions.intersections do
       local intersection: *Intersection = collisions.intersections[i]
 
@@ -205,7 +205,7 @@ global EngageSystem = @MakeSystem(EngageRunner, false, true, false, 1, record{
 
 global BridgeRunner = @record{}
 
-function BridgeRunner:run(bridge: *Bridge, collider: *Collider, sprite: *Sprite, system_data: SystemData*)
+function BridgeRunner:run(bridge: *Bridge, collider: *Collider, sprite: *Sprite, system_data: *SystemData)
    if Globals.engaged_slots[bridge.slot_idx] then
       collider.entity_tag = EntityTag.OpenBridge
       sprite.visible = true

--- a/raylib.nelua
+++ b/raylib.nelua
@@ -1,11 +1,5 @@
--- links:
---## linklib 'raylib'
-
--- includes:
-## cinclude '<raylib.h>'
-## cinclude '<raymath.h>'
-
-global TraceLogCallback = @record{}
+-- links: 
+## linklib 'raylib' 
 
 -- raylib binding:
 global Raylib = @record{}
@@ -15,13 +9,13 @@ global Raylib = @record{}
 -- Some basic Defines
 -- ----------------------------------------------------------------------------------
 
-global PI: float32 <cimport, nodecl>
+global PI: float32 <cimport, cinclude'<raylib.h>', nodecl>
 
 
-global DEG2RAD: float32 <cimport, nodecl>
-global RAD2DEG: float32 <cimport, nodecl>
+global DEG2RAD: float32 <cimport, cinclude'<raylib.h>', nodecl>
+global RAD2DEG: float32 <cimport, cinclude'<raylib.h>', nodecl>
 
-global MAX_TOUCH_POINTS: cint <cimport, nodecl>      -- Maximum number of touch points supported
+global MAX_TOUCH_POINTS: cint <cimport, cinclude'<raylib.h>', nodecl>      -- Maximum number of touch points supported
 
 
 
@@ -31,14 +25,14 @@ global MAX_TOUCH_POINTS: cint <cimport, nodecl>      -- Maximum number of touch 
 
 
 -- Vector2 type
-global Vector2 <cimport, nodecl> = @record{
+global Vector2 <cimport, cinclude'<raylib.h>', nodecl> = @record{
   x: float32,
   y: float32,
 }
 ## Vector2.value.is_vector2 = true
 
 -- Vector3 type
-global Vector3 <cimport, nodecl> = @record{
+global Vector3 <cimport, cinclude'<raylib.h>', nodecl> = @record{
   x: float32,
   y: float32,
   z: float32,
@@ -46,7 +40,7 @@ global Vector3 <cimport, nodecl> = @record{
 ## Vector3.value.is_vector3 = true
 
 -- Vector4 type
-global Vector4 <cimport, nodecl> = @record{
+global Vector4 <cimport, cinclude'<raylib.h>', nodecl> = @record{
   x: float32,
   y: float32,
   z: float32,
@@ -58,7 +52,7 @@ global Vector4 <cimport, nodecl> = @record{
 global Quaternion: type = @Vector4
 
 -- Matrix type (OpenGL style 4x4 - right handed, column major)
-global Matrix <cimport, nodecl> = @record{
+global Matrix <cimport, cinclude'<raylib.h>', nodecl> = @record{
   m0: float32, m4: float32, m8: float32, m12: float32,
   m1: float32, m5: float32, m9: float32, m13: float32,
   m2: float32, m6: float32, m10: float32, m14: float32,
@@ -67,7 +61,7 @@ global Matrix <cimport, nodecl> = @record{
 ## Matrix.value.is_matrix = true
 
 -- Color type, RGBA (32bit)
-global Color <cimport, nodecl> = @record{
+global Color <cimport, cinclude'<raylib.h>', nodecl> = @record{
   r: cuchar,
   g: cuchar,
   b: cuchar,
@@ -76,7 +70,7 @@ global Color <cimport, nodecl> = @record{
 ## Color.value.is_color = true
 
 -- Rectangle type
-global Rectangle <cimport, nodecl> = @record{
+global Rectangle <cimport, cinclude'<raylib.h>', nodecl> = @record{
   x: float32,
   y: float32,
   width: float32,
@@ -86,7 +80,7 @@ global Rectangle <cimport, nodecl> = @record{
 
 -- Image type, bpp always RGBA (32bit)
 -- NOTE: Data stored in CPU memory (RAM)
-global Image <cimport, nodecl> = @record{
+global Image <cimport, cinclude'<raylib.h>', nodecl> = @record{
   data: pointer,               -- Image raw data
   width: cint,                -- Image base width
   height: cint,               -- Image base height
@@ -97,7 +91,7 @@ global Image <cimport, nodecl> = @record{
 
 -- Texture2D type
 -- NOTE: Data stored in GPU memory
-global Texture2D <cimport, nodecl> = @record{
+global Texture2D <cimport, cinclude'<raylib.h>', nodecl> = @record{
   id: cuint,          -- OpenGL texture id
   width: cint,                -- Texture base width
   height: cint,               -- Texture base height
@@ -113,7 +107,7 @@ global Texture: type = @Texture2D
 global TextureCubemap: type = @Texture2D
 
 -- RenderTexture2D type, for texture rendering
-global RenderTexture2D <cimport, nodecl> = @record{
+global RenderTexture2D <cimport, cinclude'<raylib.h>', nodecl> = @record{
   id: cuint,          -- OpenGL Framebuffer Object (FBO) id
   texture: Texture2D,        -- Color buffer attachment texture
   depth: Texture2D,          -- Depth buffer attachment texture
@@ -125,7 +119,7 @@ global RenderTexture2D <cimport, nodecl> = @record{
 global RenderTexture: type = @RenderTexture2D
 
 -- N-Patch layout info
-global NPatchInfo <cimport, nodecl> = @record{
+global NPatchInfo <cimport, cinclude'<raylib.h>', nodecl> = @record{
   sourceRec: Rectangle,     -- Region in the texture
   left: cint,                -- left border offset
   top: cint,                 -- top border offset
@@ -136,7 +130,7 @@ global NPatchInfo <cimport, nodecl> = @record{
 ## NPatchInfo.value.is_npatchinfo = true
 
 -- Font character info
-global CharInfo <cimport, nodecl> = @record{
+global CharInfo <cimport, cinclude'<raylib.h>', nodecl> = @record{
   value: cint,                -- Character value (Unicode)
   offsetX: cint,              -- Character offset X when drawing
   offsetY: cint,              -- Character offset Y when drawing
@@ -146,19 +140,19 @@ global CharInfo <cimport, nodecl> = @record{
 ## CharInfo.value.is_charinfo = true
 
 -- Font type, includes texture and charSet array data
-global Font <cimport, nodecl> = @record{
+global Font <cimport, cinclude'<raylib.h>', nodecl> = @record{
   baseSize: cint,             -- Base size (default chars height)
   charsCount: cint,           -- Number of characters
   texture: Texture2D,        -- Characters texture atlas
-  recs: Rectangle[0]*,          -- Characters rectangles in texture
-  chars: CharInfo[0]*,          -- Characters info data
+  recs: *[0]Rectangle,          -- Characters rectangles in texture
+  chars: *[0]CharInfo,          -- Characters info data
 }
 ## Font.value.is_font = true
 
-global SpriteFont <cimport, nodecl> = Font     -- SpriteFont type fallback, defaults to Font
+global SpriteFont <cimport, cinclude'<raylib.h>', nodecl> = Font     -- SpriteFont type fallback, defaults to Font
 
 -- Camera type, defines a camera position/orientation in 3d space
-global Camera3D <cimport, nodecl> = @record{
+global Camera3D <cimport, cinclude'<raylib.h>', nodecl> = @record{
   position: Vector3,         -- Camera position
   target: Vector3,           -- Camera target it looks-at
   up: Vector3,               -- Camera up vector (rotation over its axis)
@@ -170,7 +164,7 @@ global Camera3D <cimport, nodecl> = @record{
 global Camera: type = @Camera3D    -- Camera type fallback, defaults to Camera3D
 
 -- Camera2D type, defines a 2d camera
-global Camera2D <cimport, nodecl> = @record{
+global Camera2D <cimport, cinclude'<raylib.h>', nodecl> = @record{
   offset: Vector2,           -- Camera offset (displacement from target)
   target: Vector2,           -- Camera target (rotation and zoom origin)
   rotation: float32,           -- Camera rotation in degrees
@@ -180,40 +174,40 @@ global Camera2D <cimport, nodecl> = @record{
 
 -- Vertex data definning a mesh
 -- NOTE: Data stored in CPU memory (and GPU)
-global Mesh <cimport, nodecl> = @record{
+global Mesh <cimport, cinclude'<raylib.h>', nodecl> = @record{
   vertexCount: cint,          -- Number of vertices stored in arrays
   triangleCount: cint,        -- Number of triangles stored (indexed or not)
 
   -- Default vertex data
-  vertices: float32[0]*,          -- Vertex position (XYZ - 3 components per vertex) (shader-location = 0)
-  texcoords: float32[0]*,         -- Vertex texture coordinates (UV - 2 components per vertex) (shader-location = 1)
-  texcoords2: float32[0]*,        -- Vertex second texture coordinates (useful for lightmaps) (shader-location = 5)
-  normals: float32[0]*,           -- Vertex normals (XYZ - 3 components per vertex) (shader-location = 2)
-  tangents: float32[0]*,          -- Vertex tangents (XYZW - 4 components per vertex) (shader-location = 4)
-  colors: cuchar[0]*,    -- Vertex colors (RGBA - 4 components per vertex) (shader-location = 3)
-  indices: cushort[0]*,  -- Vertex indices (in case vertex data comes indexed)
+  vertices: *[0]float32,          -- Vertex position (XYZ - 3 components per vertex) (shader-location = 0)
+  texcoords: *[0]float32,         -- Vertex texture coordinates (UV - 2 components per vertex) (shader-location = 1)
+  texcoords2: *[0]float32,        -- Vertex second texture coordinates (useful for lightmaps) (shader-location = 5)
+  normals: *[0]float32,           -- Vertex normals (XYZ - 3 components per vertex) (shader-location = 2)
+  tangents: *[0]float32,          -- Vertex tangents (XYZW - 4 components per vertex) (shader-location = 4)
+  colors: *[0]cuchar,    -- Vertex colors (RGBA - 4 components per vertex) (shader-location = 3)
+  indices: *[0]cushort,  -- Vertex indices (in case vertex data comes indexed)
 
   -- Animation vertex data
-  animVertices: float32[0]*,      -- Animated vertex positions (after bones transformations)
-  animNormals: float32[0]*,       -- Animated normals (after bones transformations)
-  boneIds: cint[0]*,             -- Vertex bone ids, up to 4 bones influence by vertex (skinning)
-  boneWeights: float32[0]*,       -- Vertex bone weight, up to 4 bones influence by vertex (skinning)
+  animVertices: *[0]float32,      -- Animated vertex positions (after bones transformations)
+  animNormals: *[0]float32,       -- Animated normals (after bones transformations)
+  boneIds: *[0]cint,             -- Vertex bone ids, up to 4 bones influence by vertex (skinning)
+  boneWeights: *[0]float32,       -- Vertex bone weight, up to 4 bones influence by vertex (skinning)
 
   -- OpenGL identifiers
   vaoId: cuint,       -- OpenGL Vertex Array Object id
-  vboId: cuint[0]*,      -- OpenGL Vertex Buffer Objects id (default vertex data)
+  vboId: *[0]cuint,      -- OpenGL Vertex Buffer Objects id (default vertex data)
 }
 ## Mesh.value.is_mesh = true
 
 -- Shader type (generic)
-global Shader <cimport, nodecl> = @record{
+global Shader <cimport, cinclude'<raylib.h>', nodecl> = @record{
   id: cuint,          -- Shader program id
-  locs: cint[0]*,                -- Shader locations array (MAX_SHADER_LOCATIONS)
+  locs: *[0]cint,                -- Shader locations array (MAX_SHADER_LOCATIONS)
 }
 ## Shader.value.is_shader = true
 
 -- Material texture map
-global MaterialMap <cimport, nodecl> = @record{
+global MaterialMap <cimport, cinclude'<raylib.h>', nodecl> = @record{
   texture: Texture2D,        -- Material map texture
   color: Color,              -- Material map color
   value: float32,              -- Material map value
@@ -221,15 +215,15 @@ global MaterialMap <cimport, nodecl> = @record{
 ## MaterialMap.value.is_materialmap = true
 
 -- Material type (generic)
-global Material <cimport, nodecl> = @record{
+global Material <cimport, cinclude'<raylib.h>', nodecl> = @record{
   shader: Shader,            -- Material shader
-  maps: MaterialMap[0]*,        -- Material maps array (MAX_MATERIAL_MAPS)
-  params: float32[0]*,            -- Material generic parameters (if required)
+  maps: *[0]MaterialMap,        -- Material maps array (MAX_MATERIAL_MAPS)
+  params: *[0]float32,            -- Material generic parameters (if required)
 }
 ## Material.value.is_material = true
 
 -- Transformation properties
-global Transform <cimport, nodecl> = @record{
+global Transform <cimport, cinclude'<raylib.h>', nodecl> = @record{
   translation: Vector3,      -- Translation
   rotation: Quaternion,      -- Rotation
   scale: Vector3,            -- Scale
@@ -237,46 +231,46 @@ global Transform <cimport, nodecl> = @record{
 ## Transform.value.is_transform = true
 
 -- Bone information
-global BoneInfo <cimport, nodecl> = @record{
-  name : cchar[32],            -- Bone name
+global BoneInfo <cimport, cinclude'<raylib.h>', nodecl> = @record{
+  name : [32]cchar,            -- Bone name
   parent: cint,               -- Bone parent
 }
 ## BoneInfo.value.is_boneinfo = true
 
 -- Model type
-global Model <cimport, nodecl> = @record{
+global Model <cimport, cinclude'<raylib.h>', nodecl> = @record{
   transform: Matrix,         -- Local transform matrix
   meshCount: cint,            -- Number of meshes
-  meshes: Mesh[0]*,             -- Meshes array
+  meshes: *[0]Mesh,             -- Meshes array
   materialCount: cint,        -- Number of materials
-  materials: Material[0]*,      -- Materials array
-  meshMaterial: cint[0]*,        -- Mesh material number
+  materials: *[0]Material,      -- Materials array
+  meshMaterial: *[0]cint,        -- Mesh material number
 
   -- Animation data
   boneCount: cint,            -- Number of bones
-  bones: BoneInfo[0]*,          -- Bones information (skeleton)
-  bindPose: Transform[0]*,      -- Bones base transformation (pose)
+  bones: *[0]BoneInfo,          -- Bones information (skeleton)
+  bindPose: *[0]Transform,      -- Bones base transformation (pose)
 }
 ## Model.value.is_model = true
 
 -- Model animation
-global ModelAnimation <cimport, nodecl> = @record{
+global ModelAnimation <cimport, cinclude'<raylib.h>', nodecl> = @record{
   boneCount: cint,            -- Number of bones
-  bones: BoneInfo[0]*,          -- Bones information (skeleton)
+  bones: *[0]BoneInfo,          -- Bones information (skeleton)
   frameCount: cint,           -- Number of animation frames
-  framePoses: Transform[0]*[0]*,   -- Poses array by frame
+  framePoses: *[0]*[0]Transform,   -- Poses array by frame
 }
 ## ModelAnimation.value.is_modelanimation = true
 
 -- Ray type (useful for raycast)
-global Ray <cimport, nodecl> = @record{
+global Ray <cimport, cinclude'<raylib.h>', nodecl> = @record{
   position: Vector3,         -- Ray position (origin)
   direction: Vector3,        -- Ray direction
 }
 ## Ray.value.is_ray = true
 
 -- Raycast hit information
-global RayHitInfo <cimport, nodecl> = @record{
+global RayHitInfo <cimport, cinclude'<raylib.h>', nodecl> = @record{
   hit: boolean,                 -- Did the ray hit something?
   distance: float32,           -- Distance to nearest hit
   position: Vector3,         -- Position of nearest hit
@@ -285,14 +279,14 @@ global RayHitInfo <cimport, nodecl> = @record{
 ## RayHitInfo.value.is_rayhitinfo = true
 
 -- Bounding box type
-global BoundingBox <cimport, nodecl> = @record{
+global BoundingBox <cimport, cinclude'<raylib.h>', nodecl> = @record{
   min: Vector3,              -- Minimum vertex box-corner
   max: Vector3,              -- Maximum vertex box-corner
 }
 ## BoundingBox.value.is_boundingbox = true
 
 -- Wave type, defines audio wave data
-global Wave <cimport, nodecl> = @record{
+global Wave <cimport, cinclude'<raylib.h>', nodecl> = @record{
   sampleCount: cuint,         -- Total number of samples
   sampleRate: cuint,          -- Frequency (samples per second)
   sampleSize: cuint,          -- Bit depth (bits per sample): 8, 16, 32 (24 not supported)
@@ -301,22 +295,22 @@ global Wave <cimport, nodecl> = @record{
 }
 ## Wave.value.is_wave = true
 
-global rAudioBuffer <cimport, nodecl> = @record{
+global rAudioBuffer <cimport, cinclude'<raylib.h>', nodecl> = @record{
 }
 ## rAudioBuffer.value.is_raudiobuffer = true
 
 -- Audio stream type
 -- NOTE: Useful to create custom audio streams not bound to a specific file
-global AudioStream <cimport, nodecl> = @record{
+global AudioStream <cimport, cinclude'<raylib.h>', nodecl> = @record{
   sampleRate: cuint,          -- Frequency (samples per second)
   sampleSize: cuint,          -- Bit depth (bits per sample): 8, 16, 32 (24 not supported)
   channels: cuint,            -- Number of channels (1-mono, 2-stereo)
-  buffer: rAudioBuffer*,             -- Pointer to internal data used by the audio system
+  buffer: *rAudioBuffer,             -- Pointer to internal data used by the audio system
 }
 ## AudioStream.value.is_audiostream = true
 
 -- Sound source type
-global Sound <cimport, nodecl> = @record{
+global Sound <cimport, cinclude'<raylib.h>', nodecl> = @record{
   sampleCount: cuint,         -- Total number of samples
   stream: AudioStream,               -- Audio stream
 }
@@ -324,7 +318,7 @@ global Sound <cimport, nodecl> = @record{
 
 -- Music stream type (audio file streaming from memory)
 -- NOTE: Anything longer than ~10 seconds should be streamed
-global Music <cimport, nodecl> = @record{
+global Music <cimport, cinclude'<raylib.h>', nodecl> = @record{
   ctxType: cint,                      -- Type of music context (audio filetype)
   ctxData: pointer,                    -- Audio context data, depends on type
   sampleCount: cuint,         -- Total number of samples
@@ -334,7 +328,7 @@ global Music <cimport, nodecl> = @record{
 ## Music.value.is_music = true
 
 -- Head-Mounted-Display device parameters
-global VrDeviceInfo <cimport, nodecl> = @record{
+global VrDeviceInfo <cimport, cinclude'<raylib.h>', nodecl> = @record{
   hResolution: cint,                  -- HMD horizontal resolution in pixels
   vResolution: cint,                  -- HMD vertical resolution in pixels
   hScreenSize: float32,                -- HMD horizontal size in meters
@@ -343,8 +337,8 @@ global VrDeviceInfo <cimport, nodecl> = @record{
   eyeToScreenDistance: float32,        -- HMD distance between eye and display in meters
   lensSeparationDistance: float32,     -- HMD lens separation distance in meters
   interpupillaryDistance: float32,     -- HMD IPD (distance between pupils) in meters
-  lensDistortionValues : float32[4],    -- HMD lens distortion constant parameters
-  chromaAbCorrection : float32[4],      -- HMD chromatic aberration correction parameters
+  lensDistortionValues : [4]float32,    -- HMD lens distortion constant parameters
+  chromaAbCorrection : [4]float32,      -- HMD chromatic aberration correction parameters
 }
 ## VrDeviceInfo.value.is_vrdeviceinfo = true
 
@@ -363,234 +357,234 @@ global ConfigFlag = @enum {
    FLAG_WINDOW_ALWAYS_RUN = 256,      -- Set to allow windows running while minimized
    FLAG_MSAA_4X_HINT = 32,       -- Set to try enabling MSAA 4X
    FLAG_VSYNC_HINT = 64,    -- Set to try enabling V-Sync on GPU
-
+ 
 }
 
 -- Trace log type
 global TraceLogType = @enum {
    LOG_ALL = 0,            -- Display all logs
-   LOG_TRACE,
-   LOG_DEBUG,
-   LOG_INFO,
-   LOG_WARNING,
-   LOG_ERROR,
-   LOG_FATAL,
+   LOG_TRACE, 
+   LOG_DEBUG, 
+   LOG_INFO, 
+   LOG_WARNING, 
+   LOG_ERROR, 
+   LOG_FATAL, 
    LOG_NONE,    -- Disable logging
-
+ 
 }
 
 -- Keyboard keys
 global KeyboardKey = @enum {
     -- Alphanumeric keys
-   KEY_APOSTROPHE = 39,
-   KEY_COMMA = 44,
-   KEY_MINUS = 45,
-   KEY_PERIOD = 46,
-   KEY_SLASH = 47,
-   KEY_ZERO = 48,
-   KEY_ONE = 49,
-   KEY_TWO = 50,
-   KEY_THREE = 51,
-   KEY_FOUR = 52,
-   KEY_FIVE = 53,
-   KEY_SIX = 54,
-   KEY_SEVEN = 55,
-   KEY_EIGHT = 56,
-   KEY_NINE = 57,
-   KEY_SEMICOLON = 59,
-   KEY_EQUAL = 61,
-   KEY_A = 65,
-   KEY_B = 66,
-   KEY_C = 67,
-   KEY_D = 68,
-   KEY_E = 69,
-   KEY_F = 70,
-   KEY_G = 71,
-   KEY_H = 72,
-   KEY_I = 73,
-   KEY_J = 74,
-   KEY_K = 75,
-   KEY_L = 76,
-   KEY_M = 77,
-   KEY_N = 78,
-   KEY_O = 79,
-   KEY_P = 80,
-   KEY_Q = 81,
-   KEY_R = 82,
-   KEY_S = 83,
-   KEY_T = 84,
-   KEY_U = 85,
-   KEY_V = 86,
-   KEY_W = 87,
-   KEY_X = 88,
-   KEY_Y = 89,
-   KEY_Z = 90,
+   KEY_APOSTROPHE = 39, 
+   KEY_COMMA = 44, 
+   KEY_MINUS = 45, 
+   KEY_PERIOD = 46, 
+   KEY_SLASH = 47, 
+   KEY_ZERO = 48, 
+   KEY_ONE = 49, 
+   KEY_TWO = 50, 
+   KEY_THREE = 51, 
+   KEY_FOUR = 52, 
+   KEY_FIVE = 53, 
+   KEY_SIX = 54, 
+   KEY_SEVEN = 55, 
+   KEY_EIGHT = 56, 
+   KEY_NINE = 57, 
+   KEY_SEMICOLON = 59, 
+   KEY_EQUAL = 61, 
+   KEY_A = 65, 
+   KEY_B = 66, 
+   KEY_C = 67, 
+   KEY_D = 68, 
+   KEY_E = 69, 
+   KEY_F = 70, 
+   KEY_G = 71, 
+   KEY_H = 72, 
+   KEY_I = 73, 
+   KEY_J = 74, 
+   KEY_K = 75, 
+   KEY_L = 76, 
+   KEY_M = 77, 
+   KEY_N = 78, 
+   KEY_O = 79, 
+   KEY_P = 80, 
+   KEY_Q = 81, 
+   KEY_R = 82, 
+   KEY_S = 83, 
+   KEY_T = 84, 
+   KEY_U = 85, 
+   KEY_V = 86, 
+   KEY_W = 87, 
+   KEY_X = 88, 
+   KEY_Y = 89, 
+   KEY_Z = 90, 
    -- Function keys
-   KEY_SPACE = 32,
-   KEY_ESCAPE = 256,
-   KEY_ENTER = 257,
-   KEY_TAB = 258,
-   KEY_BACKSPACE = 259,
-   KEY_INSERT = 260,
-   KEY_DELETE = 261,
-   KEY_RIGHT = 262,
-   KEY_LEFT = 263,
-   KEY_DOWN = 264,
-   KEY_UP = 265,
-   KEY_PAGE_UP = 266,
-   KEY_PAGE_DOWN = 267,
-   KEY_HOME = 268,
-   KEY_END = 269,
-   KEY_CAPS_LOCK = 280,
-   KEY_SCROLL_LOCK = 281,
-   KEY_NUM_LOCK = 282,
-   KEY_PRINT_SCREEN = 283,
-   KEY_PAUSE = 284,
-   KEY_F1 = 290,
-   KEY_F2 = 291,
-   KEY_F3 = 292,
-   KEY_F4 = 293,
-   KEY_F5 = 294,
-   KEY_F6 = 295,
-   KEY_F7 = 296,
-   KEY_F8 = 297,
-   KEY_F9 = 298,
-   KEY_F10 = 299,
-   KEY_F11 = 300,
-   KEY_F12 = 301,
-   KEY_LEFT_SHIFT = 340,
-   KEY_LEFT_CONTROL = 341,
-   KEY_LEFT_ALT = 342,
-   KEY_LEFT_SUPER = 343,
-   KEY_RIGHT_SHIFT = 344,
-   KEY_RIGHT_CONTROL = 345,
-   KEY_RIGHT_ALT = 346,
-   KEY_RIGHT_SUPER = 347,
-   KEY_KB_MENU = 348,
-   KEY_LEFT_BRACKET = 91,
-   KEY_BACKSLASH = 92,
-   KEY_RIGHT_BRACKET = 93,
-   KEY_GRAVE = 96,
+   KEY_SPACE = 32, 
+   KEY_ESCAPE = 256, 
+   KEY_ENTER = 257, 
+   KEY_TAB = 258, 
+   KEY_BACKSPACE = 259, 
+   KEY_INSERT = 260, 
+   KEY_DELETE = 261, 
+   KEY_RIGHT = 262, 
+   KEY_LEFT = 263, 
+   KEY_DOWN = 264, 
+   KEY_UP = 265, 
+   KEY_PAGE_UP = 266, 
+   KEY_PAGE_DOWN = 267, 
+   KEY_HOME = 268, 
+   KEY_END = 269, 
+   KEY_CAPS_LOCK = 280, 
+   KEY_SCROLL_LOCK = 281, 
+   KEY_NUM_LOCK = 282, 
+   KEY_PRINT_SCREEN = 283, 
+   KEY_PAUSE = 284, 
+   KEY_F1 = 290, 
+   KEY_F2 = 291, 
+   KEY_F3 = 292, 
+   KEY_F4 = 293, 
+   KEY_F5 = 294, 
+   KEY_F6 = 295, 
+   KEY_F7 = 296, 
+   KEY_F8 = 297, 
+   KEY_F9 = 298, 
+   KEY_F10 = 299, 
+   KEY_F11 = 300, 
+   KEY_F12 = 301, 
+   KEY_LEFT_SHIFT = 340, 
+   KEY_LEFT_CONTROL = 341, 
+   KEY_LEFT_ALT = 342, 
+   KEY_LEFT_SUPER = 343, 
+   KEY_RIGHT_SHIFT = 344, 
+   KEY_RIGHT_CONTROL = 345, 
+   KEY_RIGHT_ALT = 346, 
+   KEY_RIGHT_SUPER = 347, 
+   KEY_KB_MENU = 348, 
+   KEY_LEFT_BRACKET = 91, 
+   KEY_BACKSLASH = 92, 
+   KEY_RIGHT_BRACKET = 93, 
+   KEY_GRAVE = 96, 
    -- Keypad keys
-   KEY_KP_0 = 320,
-   KEY_KP_1 = 321,
-   KEY_KP_2 = 322,
-   KEY_KP_3 = 323,
-   KEY_KP_4 = 324,
-   KEY_KP_5 = 325,
-   KEY_KP_6 = 326,
-   KEY_KP_7 = 327,
-   KEY_KP_8 = 328,
-   KEY_KP_9 = 329,
-   KEY_KP_DECIMAL = 330,
-   KEY_KP_DIVIDE = 331,
-   KEY_KP_MULTIPLY = 332,
-   KEY_KP_SUBTRACT = 333,
-   KEY_KP_ADD = 334,
-   KEY_KP_ENTER = 335,
-   KEY_KP_EQUAL = 336,
+   KEY_KP_0 = 320, 
+   KEY_KP_1 = 321, 
+   KEY_KP_2 = 322, 
+   KEY_KP_3 = 323, 
+   KEY_KP_4 = 324, 
+   KEY_KP_5 = 325, 
+   KEY_KP_6 = 326, 
+   KEY_KP_7 = 327, 
+   KEY_KP_8 = 328, 
+   KEY_KP_9 = 329, 
+   KEY_KP_DECIMAL = 330, 
+   KEY_KP_DIVIDE = 331, 
+   KEY_KP_MULTIPLY = 332, 
+   KEY_KP_SUBTRACT = 333, 
+   KEY_KP_ADD = 334, 
+   KEY_KP_ENTER = 335, 
+   KEY_KP_EQUAL = 336,  
 }
 
 -- Android buttons
 global AndroidButton = @enum {
-   KEY_BACK = 4,
-   KEY_MENU = 82,
-   KEY_VOLUME_UP = 24,
-   KEY_VOLUME_DOWN = 25,
+   KEY_BACK = 4, 
+   KEY_MENU = 82, 
+   KEY_VOLUME_UP = 24, 
+   KEY_VOLUME_DOWN = 25,  
 }
 
 -- Mouse buttons
 global MouseButton = @enum {
-   MOUSE_LEFT_BUTTON = 0,
-   MOUSE_RIGHT_BUTTON = 1,
-   MOUSE_MIDDLE_BUTTON = 2,
+   MOUSE_LEFT_BUTTON = 0, 
+   MOUSE_RIGHT_BUTTON = 1, 
+   MOUSE_MIDDLE_BUTTON = 2,  
 }
 
 -- Gamepad number
 global GamepadNumber = @enum {
-   GAMEPAD_PLAYER1 = 0,
-   GAMEPAD_PLAYER2 = 1,
-   GAMEPAD_PLAYER3 = 2,
-   GAMEPAD_PLAYER4 = 3,
+   GAMEPAD_PLAYER1 = 0, 
+   GAMEPAD_PLAYER2 = 1, 
+   GAMEPAD_PLAYER3 = 2, 
+   GAMEPAD_PLAYER4 = 3,  
 }
 
 -- Gamepad Buttons
 global GamepadButton = @enum {
     -- This is here just for error checking
-   GAMEPAD_BUTTON_UNKNOWN = 0,
+   GAMEPAD_BUTTON_UNKNOWN = 0, 
    -- This is normally a DPAD
-   GAMEPAD_BUTTON_LEFT_FACE_UP,
-   GAMEPAD_BUTTON_LEFT_FACE_RIGHT,
-   GAMEPAD_BUTTON_LEFT_FACE_DOWN,
-   GAMEPAD_BUTTON_LEFT_FACE_LEFT,
+   GAMEPAD_BUTTON_LEFT_FACE_UP, 
+   GAMEPAD_BUTTON_LEFT_FACE_RIGHT, 
+   GAMEPAD_BUTTON_LEFT_FACE_DOWN, 
+   GAMEPAD_BUTTON_LEFT_FACE_LEFT, 
    -- This normally corresponds with PlayStation and Xbox controllers
-
+ 
    -- XBOX: [Y,X,A,B]
-
+ 
    -- PS3: [Triangle,Square,Cross,Circle]
-
+ 
    -- No support for 6 button controllers though..
-   GAMEPAD_BUTTON_RIGHT_FACE_UP,
-   GAMEPAD_BUTTON_RIGHT_FACE_RIGHT,
-   GAMEPAD_BUTTON_RIGHT_FACE_DOWN,
-   GAMEPAD_BUTTON_RIGHT_FACE_LEFT,
+   GAMEPAD_BUTTON_RIGHT_FACE_UP, 
+   GAMEPAD_BUTTON_RIGHT_FACE_RIGHT, 
+   GAMEPAD_BUTTON_RIGHT_FACE_DOWN, 
+   GAMEPAD_BUTTON_RIGHT_FACE_LEFT, 
    -- Triggers
-   GAMEPAD_BUTTON_LEFT_TRIGGER_1,
-   GAMEPAD_BUTTON_LEFT_TRIGGER_2,
-   GAMEPAD_BUTTON_RIGHT_TRIGGER_1,
-   GAMEPAD_BUTTON_RIGHT_TRIGGER_2,
+   GAMEPAD_BUTTON_LEFT_TRIGGER_1, 
+   GAMEPAD_BUTTON_LEFT_TRIGGER_2, 
+   GAMEPAD_BUTTON_RIGHT_TRIGGER_1, 
+   GAMEPAD_BUTTON_RIGHT_TRIGGER_2, 
    -- These are buttons in the center of the gamepad
    GAMEPAD_BUTTON_MIDDLE_LEFT,         -- PS3 Select
    GAMEPAD_BUTTON_MIDDLE,              -- PS Button/XBOX Button
    GAMEPAD_BUTTON_MIDDLE_RIGHT,        -- PS3 Start
-
+ 
    -- These are the joystick press in buttons
-   GAMEPAD_BUTTON_LEFT_THUMB,
-   GAMEPAD_BUTTON_RIGHT_THUMB,
+   GAMEPAD_BUTTON_LEFT_THUMB, 
+   GAMEPAD_BUTTON_RIGHT_THUMB,  
 }
 
 global GamepadAxis = @enum {
     -- This is here just for error checking
-   GAMEPAD_AXIS_UNKNOWN = 0,
+   GAMEPAD_AXIS_UNKNOWN = 0, 
    -- Left stick
-   GAMEPAD_AXIS_LEFT_X,
-   GAMEPAD_AXIS_LEFT_Y,
+   GAMEPAD_AXIS_LEFT_X, 
+   GAMEPAD_AXIS_LEFT_Y, 
    -- Right stick
-   GAMEPAD_AXIS_RIGHT_X,
-   GAMEPAD_AXIS_RIGHT_Y,
+   GAMEPAD_AXIS_RIGHT_X, 
+   GAMEPAD_AXIS_RIGHT_Y, 
    -- Pressure levels for the back triggers
    GAMEPAD_AXIS_LEFT_TRIGGER,          -- [1..-1] (pressure-level)
    GAMEPAD_AXIS_RIGHT_TRIGGER,    -- [1..-1] (pressure-level)
-
+ 
 }
 
 -- Shader location point type
 global ShaderLocationIndex = @enum {
-   LOC_VERTEX_POSITION = 0,
-   LOC_VERTEX_TEXCOORD01,
-   LOC_VERTEX_TEXCOORD02,
-   LOC_VERTEX_NORMAL,
-   LOC_VERTEX_TANGENT,
-   LOC_VERTEX_COLOR,
-   LOC_MATRIX_MVP,
-   LOC_MATRIX_MODEL,
-   LOC_MATRIX_VIEW,
-   LOC_MATRIX_PROJECTION,
-   LOC_VECTOR_VIEW,
-   LOC_COLOR_DIFFUSE,
-   LOC_COLOR_SPECULAR,
-   LOC_COLOR_AMBIENT,
+   LOC_VERTEX_POSITION = 0, 
+   LOC_VERTEX_TEXCOORD01, 
+   LOC_VERTEX_TEXCOORD02, 
+   LOC_VERTEX_NORMAL, 
+   LOC_VERTEX_TANGENT, 
+   LOC_VERTEX_COLOR, 
+   LOC_MATRIX_MVP, 
+   LOC_MATRIX_MODEL, 
+   LOC_MATRIX_VIEW, 
+   LOC_MATRIX_PROJECTION, 
+   LOC_VECTOR_VIEW, 
+   LOC_COLOR_DIFFUSE, 
+   LOC_COLOR_SPECULAR, 
+   LOC_COLOR_AMBIENT, 
    LOC_MAP_ALBEDO,              -- LOC_MAP_DIFFUSE
    LOC_MAP_METALNESS,           -- LOC_MAP_SPECULAR
-   LOC_MAP_NORMAL,
-   LOC_MAP_ROUGHNESS,
-   LOC_MAP_OCCLUSION,
-   LOC_MAP_EMISSION,
-   LOC_MAP_HEIGHT,
-   LOC_MAP_CUBEMAP,
-   LOC_MAP_IRRADIANCE,
-   LOC_MAP_PREFILTER,
-   LOC_MAP_BRDF,
+   LOC_MAP_NORMAL, 
+   LOC_MAP_ROUGHNESS, 
+   LOC_MAP_OCCLUSION, 
+   LOC_MAP_EMISSION, 
+   LOC_MAP_HEIGHT, 
+   LOC_MAP_CUBEMAP, 
+   LOC_MAP_IRRADIANCE, 
+   LOC_MAP_PREFILTER, 
+   LOC_MAP_BRDF,  
 }
 
 -- ignored, because I don't know how this should be handled:
@@ -599,30 +593,30 @@ global ShaderLocationIndex = @enum {
 
 -- Shader uniform data types
 global ShaderUniformDataType = @enum {
-   UNIFORM_FLOAT = 0,
-   UNIFORM_VEC2,
-   UNIFORM_VEC3,
-   UNIFORM_VEC4,
-   UNIFORM_INT,
-   UNIFORM_IVEC2,
-   UNIFORM_IVEC3,
-   UNIFORM_IVEC4,
-   UNIFORM_SAMPLER2D,
+   UNIFORM_FLOAT = 0, 
+   UNIFORM_VEC2, 
+   UNIFORM_VEC3, 
+   UNIFORM_VEC4, 
+   UNIFORM_INT, 
+   UNIFORM_IVEC2, 
+   UNIFORM_IVEC3, 
+   UNIFORM_IVEC4, 
+   UNIFORM_SAMPLER2D,  
 }
 
 -- Material map type
 global MaterialMapType = @enum {
    MAP_ALBEDO = 0,           -- MAP_DIFFUSE
    MAP_METALNESS = 1,           -- MAP_SPECULAR
-   MAP_NORMAL = 2,
-   MAP_ROUGHNESS = 3,
-   MAP_OCCLUSION,
-   MAP_EMISSION,
-   MAP_HEIGHT,
+   MAP_NORMAL = 2, 
+   MAP_ROUGHNESS = 3, 
+   MAP_OCCLUSION, 
+   MAP_EMISSION, 
+   MAP_HEIGHT, 
    MAP_CUBEMAP,                 -- NOTE: Uses GL_TEXTURE_CUBE_MAP
    MAP_IRRADIANCE,              -- NOTE: Uses GL_TEXTURE_CUBE_MAP
    MAP_PREFILTER,               -- NOTE: Uses GL_TEXTURE_CUBE_MAP
-   MAP_BRDF,
+   MAP_BRDF,  
 }
 
 -- ignored, because I don't know how this should be handled:
@@ -653,7 +647,7 @@ global PixelFormat = @enum {
    COMPRESSED_PVRT_RGBA,               -- 4 bpp
    COMPRESSED_ASTC_4x4_RGBA,           -- 8 bpp
    COMPRESSED_ASTC_8x8_RGBA,    -- 2 bpp
-
+ 
 }
 
 -- Texture parameters: filter mode
@@ -666,7 +660,7 @@ global TextureFilterMode = @enum {
    FILTER_ANISOTROPIC_4X,              -- Anisotropic filtering 4x
    FILTER_ANISOTROPIC_8X,              -- Anisotropic filtering 8x
    FILTER_ANISOTROPIC_16X,             -- Anisotropic filtering 16x
-
+ 
 }
 
 -- Cubemap layout type
@@ -677,7 +671,7 @@ global CubemapLayoutType = @enum {
    CUBEMAP_CROSS_THREE_BY_FOUR,        -- Layout is defined by a 3x4 cross with cubemap faces
    CUBEMAP_CROSS_FOUR_BY_THREE,        -- Layout is defined by a 4x3 cross with cubemap faces
    CUBEMAP_PANORAMA,    -- Layout is defined by a panorama image (equirectangular map)
-
+ 
 }
 
 -- Texture parameters: wrap mode
@@ -686,7 +680,7 @@ global TextureWrapMode = @enum {
    WRAP_CLAMP,                 -- Clamps texture to edge pixel in tiled mode
    WRAP_MIRROR_REPEAT,         -- Mirrors and repeats the texture in tiled mode
    WRAP_MIRROR_CLAMP,    -- Mirrors and clamps to border the texture in tiled mode
-
+ 
 }
 
 -- Font type, defines generation method
@@ -694,7 +688,7 @@ global FontType = @enum {
    FONT_DEFAULT = 0,           -- Default font generation, anti-aliased
    FONT_BITMAP,                -- Bitmap font generation, no anti-aliasing
    FONT_SDF,    -- SDF font generation, requires external shader
-
+ 
 }
 
 -- Color blending modes (pre-defined)
@@ -702,38 +696,38 @@ global BlendMode = @enum {
    BLEND_ALPHA = 0,            -- Blend textures considering alpha (default)
    BLEND_ADDITIVE,             -- Blend textures adding colors
    BLEND_MULTIPLIED,    -- Blend textures multiplying colors
-
+ 
 }
 
 -- Gestures type
 -- NOTE: It could be used as flags to enable only some gestures
 global GestureType = @enum {
-   GESTURE_NONE = 0,
-   GESTURE_TAP = 1,
-   GESTURE_DOUBLETAP = 2,
-   GESTURE_HOLD = 4,
-   GESTURE_DRAG = 8,
-   GESTURE_SWIPE_RIGHT = 16,
-   GESTURE_SWIPE_LEFT = 32,
-   GESTURE_SWIPE_UP = 64,
-   GESTURE_SWIPE_DOWN = 128,
-   GESTURE_PINCH_IN = 256,
-   GESTURE_PINCH_OUT = 512,
+   GESTURE_NONE = 0, 
+   GESTURE_TAP = 1, 
+   GESTURE_DOUBLETAP = 2, 
+   GESTURE_HOLD = 4, 
+   GESTURE_DRAG = 8, 
+   GESTURE_SWIPE_RIGHT = 16, 
+   GESTURE_SWIPE_LEFT = 32, 
+   GESTURE_SWIPE_UP = 64, 
+   GESTURE_SWIPE_DOWN = 128, 
+   GESTURE_PINCH_IN = 256, 
+   GESTURE_PINCH_OUT = 512,  
 }
 
 -- Camera system modes
 global CameraMode = @enum {
-   CAMERA_CUSTOM = 0,
-   CAMERA_FREE,
-   CAMERA_ORBITAL,
-   CAMERA_FIRST_PERSON,
-   CAMERA_THIRD_PERSON,
+   CAMERA_CUSTOM = 0, 
+   CAMERA_FREE, 
+   CAMERA_ORBITAL, 
+   CAMERA_FIRST_PERSON, 
+   CAMERA_THIRD_PERSON,  
 }
 
 -- Camera projection modes
 global CameraType = @enum {
-   CAMERA_PERSPECTIVE = 0,
-   CAMERA_ORTHOGRAPHIC,
+   CAMERA_PERSPECTIVE = 0, 
+   CAMERA_ORTHOGRAPHIC,  
 }
 
 -- Type of n-patch
@@ -741,7 +735,7 @@ global NPatchType = @enum {
    NPT_9PATCH = 0,             -- Npatch defined by 3x3 tiles
    NPT_3PATCH_VERTICAL,        -- Npatch defined by 1x3 tiles
    NPT_3PATCH_HORIZONTAL,    -- Npatch defined by 3x1 tiles
-
+ 
 }
 
 -- Callbacks to be implemented by users
@@ -758,234 +752,236 @@ global NPatchType = @enum {
 -- ------------------------------------------------------------------------------------
 
 -- Window-related functions
-function Raylib.InitWindow(width: cint, height: cint, title: cstring): void <cimport'InitWindow', nodecl> end -- Initialize window and OpenGL context
-function Raylib.WindowShouldClose(): boolean <cimport'WindowShouldClose', nodecl> end -- Check if KEY_ESCAPE pressed or Close icon pressed
-function Raylib.CloseWindow(): void <cimport'CloseWindow', nodecl> end -- Close window and unload OpenGL context
-function Raylib.IsWindowReady(): boolean <cimport'IsWindowReady', nodecl> end -- Check if window has been initialized successfully
-function Raylib.IsWindowMinimized(): boolean <cimport'IsWindowMinimized', nodecl> end -- Check if window has been minimized (or lost focus)
-function Raylib.IsWindowResized(): boolean <cimport'IsWindowResized', nodecl> end -- Check if window has been resized
-function Raylib.IsWindowHidden(): boolean <cimport'IsWindowHidden', nodecl> end -- Check if window is currently hidden
-function Raylib.IsWindowFullscreen(): boolean <cimport'IsWindowFullscreen', nodecl> end -- Check if window is currently fullscreen
-function Raylib.ToggleFullscreen(): void <cimport'ToggleFullscreen', nodecl> end -- Toggle fullscreen mode (only PLATFORM_DESKTOP)
-function Raylib.UnhideWindow(): void <cimport'UnhideWindow', nodecl> end -- Show the window
-function Raylib.HideWindow(): void <cimport'HideWindow', nodecl> end -- Hide the window
-function Raylib.SetWindowIcon(image: Image): void <cimport'SetWindowIcon', nodecl> end -- Set icon for window (only PLATFORM_DESKTOP)
-function Raylib.SetWindowTitle(title: cstring): void <cimport'SetWindowTitle', nodecl> end -- Set title for window (only PLATFORM_DESKTOP)
-function Raylib.SetWindowPosition(x: cint, y: cint): void <cimport'SetWindowPosition', nodecl> end -- Set window position on screen (only PLATFORM_DESKTOP)
-function Raylib.SetWindowMonitor(monitor: cint): void <cimport'SetWindowMonitor', nodecl> end -- Set monitor for the current window (fullscreen mode)
-function Raylib.SetWindowMinSize(width: cint, height: cint): void <cimport'SetWindowMinSize', nodecl> end -- Set window minimum dimensions (for FLAG_WINDOW_RESIZABLE)
-function Raylib.SetWindowSize(width: cint, height: cint): void <cimport'SetWindowSize', nodecl> end -- Set window dimensions
-function Raylib.GetWindowHandle(): pointer <cimport'GetWindowHandle', nodecl> end -- Get native window handle
-function Raylib.GetScreenWidth(): cint <cimport'GetScreenWidth', nodecl> end -- Get current screen width
-function Raylib.GetScreenHeight(): cint <cimport'GetScreenHeight', nodecl> end -- Get current screen height
-function Raylib.GetMonitorCount(): cint <cimport'GetMonitorCount', nodecl> end -- Get number of connected monitors
-function Raylib.GetMonitorWidth(monitor: cint): cint <cimport'GetMonitorWidth', nodecl> end -- Get primary monitor width
-function Raylib.GetMonitorHeight(monitor: cint): cint <cimport'GetMonitorHeight', nodecl> end -- Get primary monitor height
-function Raylib.GetMonitorPhysicalWidth(monitor: cint): cint <cimport'GetMonitorPhysicalWidth', nodecl> end -- Get primary monitor physical width in millimetres
-function Raylib.GetMonitorPhysicalHeight(monitor: cint): cint <cimport'GetMonitorPhysicalHeight', nodecl> end -- Get primary monitor physical height in millimetres
-function Raylib.GetWindowPosition(): Vector2 <cimport'GetWindowPosition', nodecl> end -- Get window position XY on monitor
-function Raylib.GetMonitorName(monitor: cint): cstring <cimport'GetMonitorName', nodecl> end -- Get the human-readable, UTF-8 encoded name of the primary monitor
-function Raylib.GetClipboardText(): cstring <cimport'GetClipboardText', nodecl> end -- Get clipboard text content
-function Raylib.SetClipboardText(text: cstring): void <cimport'SetClipboardText', nodecl> end -- Set clipboard text content
+function Raylib.InitWindow(width: cint, height: cint, title: cstring): void <cimport'InitWindow', cinclude'<raylib.h>', nodecl> end -- Initialize window and OpenGL context
+function Raylib.WindowShouldClose(): boolean <cimport'WindowShouldClose', cinclude'<raylib.h>', nodecl> end -- Check if KEY_ESCAPE pressed or Close icon pressed
+function Raylib.CloseWindow(): void <cimport'CloseWindow', cinclude'<raylib.h>', nodecl> end -- Close window and unload OpenGL context
+function Raylib.IsWindowReady(): boolean <cimport'IsWindowReady', cinclude'<raylib.h>', nodecl> end -- Check if window has been initialized successfully
+function Raylib.IsWindowMinimized(): boolean <cimport'IsWindowMinimized', cinclude'<raylib.h>', nodecl> end -- Check if window has been minimized (or lost focus)
+function Raylib.IsWindowResized(): boolean <cimport'IsWindowResized', cinclude'<raylib.h>', nodecl> end -- Check if window has been resized
+function Raylib.IsWindowHidden(): boolean <cimport'IsWindowHidden', cinclude'<raylib.h>', nodecl> end -- Check if window is currently hidden
+function Raylib.IsWindowFullscreen(): boolean <cimport'IsWindowFullscreen', cinclude'<raylib.h>', nodecl> end -- Check if window is currently fullscreen
+function Raylib.ToggleFullscreen(): void <cimport'ToggleFullscreen', cinclude'<raylib.h>', nodecl> end -- Toggle fullscreen mode (only PLATFORM_DESKTOP)
+function Raylib.UnhideWindow(): void <cimport'UnhideWindow', cinclude'<raylib.h>', nodecl> end -- Show the window
+function Raylib.HideWindow(): void <cimport'HideWindow', cinclude'<raylib.h>', nodecl> end -- Hide the window
+function Raylib.SetWindowIcon(image: Image): void <cimport'SetWindowIcon', cinclude'<raylib.h>', nodecl> end -- Set icon for window (only PLATFORM_DESKTOP)
+function Raylib.SetWindowTitle(title: cstring): void <cimport'SetWindowTitle', cinclude'<raylib.h>', nodecl> end -- Set title for window (only PLATFORM_DESKTOP)
+function Raylib.SetWindowPosition(x: cint, y: cint): void <cimport'SetWindowPosition', cinclude'<raylib.h>', nodecl> end -- Set window position on screen (only PLATFORM_DESKTOP)
+function Raylib.SetWindowMonitor(monitor: cint): void <cimport'SetWindowMonitor', cinclude'<raylib.h>', nodecl> end -- Set monitor for the current window (fullscreen mode)
+function Raylib.SetWindowMinSize(width: cint, height: cint): void <cimport'SetWindowMinSize', cinclude'<raylib.h>', nodecl> end -- Set window minimum dimensions (for FLAG_WINDOW_RESIZABLE)
+function Raylib.SetWindowSize(width: cint, height: cint): void <cimport'SetWindowSize', cinclude'<raylib.h>', nodecl> end -- Set window dimensions
+function Raylib.GetWindowHandle(): pointer <cimport'GetWindowHandle', cinclude'<raylib.h>', nodecl> end -- Get native window handle
+function Raylib.GetScreenWidth(): cint <cimport'GetScreenWidth', cinclude'<raylib.h>', nodecl> end -- Get current screen width
+function Raylib.GetScreenHeight(): cint <cimport'GetScreenHeight', cinclude'<raylib.h>', nodecl> end -- Get current screen height
+function Raylib.GetMonitorCount(): cint <cimport'GetMonitorCount', cinclude'<raylib.h>', nodecl> end -- Get number of connected monitors
+function Raylib.GetMonitorWidth(monitor: cint): cint <cimport'GetMonitorWidth', cinclude'<raylib.h>', nodecl> end -- Get primary monitor width
+function Raylib.GetMonitorHeight(monitor: cint): cint <cimport'GetMonitorHeight', cinclude'<raylib.h>', nodecl> end -- Get primary monitor height
+function Raylib.GetMonitorPhysicalWidth(monitor: cint): cint <cimport'GetMonitorPhysicalWidth', cinclude'<raylib.h>', nodecl> end -- Get primary monitor physical width in millimetres
+function Raylib.GetMonitorPhysicalHeight(monitor: cint): cint <cimport'GetMonitorPhysicalHeight', cinclude'<raylib.h>', nodecl> end -- Get primary monitor physical height in millimetres
+function Raylib.GetWindowPosition(): Vector2 <cimport'GetWindowPosition', cinclude'<raylib.h>', nodecl> end -- Get window position XY on monitor
+function Raylib.GetMonitorName(monitor: cint): cstring <cimport'GetMonitorName', cinclude'<raylib.h>', nodecl> end -- Get the human-readable, UTF-8 encoded name of the primary monitor
+function Raylib.GetClipboardText(): cstring <cimport'GetClipboardText', cinclude'<raylib.h>', nodecl> end -- Get clipboard text content
+function Raylib.SetClipboardText(text: cstring): void <cimport'SetClipboardText', cinclude'<raylib.h>', nodecl> end -- Set clipboard text content
 
 -- Cursor-related functions
-function Raylib.ShowCursor(): void <cimport'ShowCursor', nodecl> end -- Shows cursor
-function Raylib.HideCursor(): void <cimport'HideCursor', nodecl> end -- Hides cursor
-function Raylib.IsCursorHidden(): boolean <cimport'IsCursorHidden', nodecl> end -- Check if cursor is not visible
-function Raylib.EnableCursor(): void <cimport'EnableCursor', nodecl> end -- Enables cursor (unlock cursor)
-function Raylib.DisableCursor(): void <cimport'DisableCursor', nodecl> end -- Disables cursor (lock cursor)
+function Raylib.ShowCursor(): void <cimport'ShowCursor', cinclude'<raylib.h>', nodecl> end -- Shows cursor
+function Raylib.HideCursor(): void <cimport'HideCursor', cinclude'<raylib.h>', nodecl> end -- Hides cursor
+function Raylib.IsCursorHidden(): boolean <cimport'IsCursorHidden', cinclude'<raylib.h>', nodecl> end -- Check if cursor is not visible
+function Raylib.EnableCursor(): void <cimport'EnableCursor', cinclude'<raylib.h>', nodecl> end -- Enables cursor (unlock cursor)
+function Raylib.DisableCursor(): void <cimport'DisableCursor', cinclude'<raylib.h>', nodecl> end -- Disables cursor (lock cursor)
 
 -- Drawing-related functions
-function Raylib.ClearBackground(color: Color): void <cimport'ClearBackground', nodecl> end -- Set background color (framebuffer clear color)
-function Raylib.BeginDrawing(): void <cimport'BeginDrawing', nodecl> end -- Setup canvas (framebuffer) to start drawing
-function Raylib.EndDrawing(): void <cimport'EndDrawing', nodecl> end -- End canvas drawing and swap buffers (double buffering)
-function Raylib.BeginMode2D(camera: Camera2D): void <cimport'BeginMode2D', nodecl> end -- Initialize 2D mode with custom camera (2D)
-function Raylib.EndMode2D(): void <cimport'EndMode2D', nodecl> end -- Ends 2D mode with custom camera
-function Raylib.BeginMode3D(camera: Camera3D): void <cimport'BeginMode3D', nodecl> end -- Initializes 3D mode with custom camera (3D)
-function Raylib.EndMode3D(): void <cimport'EndMode3D', nodecl> end -- Ends 3D mode and returns to default 2D orthographic mode
-function Raylib.BeginTextureMode(target: RenderTexture2D): void <cimport'BeginTextureMode', nodecl> end -- Initializes render texture for drawing
-function Raylib.EndTextureMode(): void <cimport'EndTextureMode', nodecl> end -- Ends drawing to render texture
-function Raylib.BeginScissorMode(x: cint, y: cint, width: cint, height: cint): void <cimport'BeginScissorMode', nodecl> end -- Begin scissor mode (define screen area for following drawing)
-function Raylib.EndScissorMode(): void <cimport'EndScissorMode', nodecl> end -- End scissor mode
+function Raylib.ClearBackground(color: Color): void <cimport'ClearBackground', cinclude'<raylib.h>', nodecl> end -- Set background color (framebuffer clear color)
+function Raylib.BeginDrawing(): void <cimport'BeginDrawing', cinclude'<raylib.h>', nodecl> end -- Setup canvas (framebuffer) to start drawing
+function Raylib.EndDrawing(): void <cimport'EndDrawing', cinclude'<raylib.h>', nodecl> end -- End canvas drawing and swap buffers (double buffering)
+function Raylib.BeginMode2D(camera: Camera2D): void <cimport'BeginMode2D', cinclude'<raylib.h>', nodecl> end -- Initialize 2D mode with custom camera (2D)
+function Raylib.EndMode2D(): void <cimport'EndMode2D', cinclude'<raylib.h>', nodecl> end -- Ends 2D mode with custom camera
+function Raylib.BeginMode3D(camera: Camera3D): void <cimport'BeginMode3D', cinclude'<raylib.h>', nodecl> end -- Initializes 3D mode with custom camera (3D)
+function Raylib.EndMode3D(): void <cimport'EndMode3D', cinclude'<raylib.h>', nodecl> end -- Ends 3D mode and returns to default 2D orthographic mode
+function Raylib.BeginTextureMode(target: RenderTexture2D): void <cimport'BeginTextureMode', cinclude'<raylib.h>', nodecl> end -- Initializes render texture for drawing
+function Raylib.EndTextureMode(): void <cimport'EndTextureMode', cinclude'<raylib.h>', nodecl> end -- Ends drawing to render texture
+function Raylib.BeginScissorMode(x: cint, y: cint, width: cint, height: cint): void <cimport'BeginScissorMode', cinclude'<raylib.h>', nodecl> end -- Begin scissor mode (define screen area for following drawing)
+function Raylib.EndScissorMode(): void <cimport'EndScissorMode', cinclude'<raylib.h>', nodecl> end -- End scissor mode
 
 -- Screen-space-related functions
-function Raylib.GetMouseRay(mousePosition: Vector2, camera: Camera): Ray <cimport'GetMouseRay', nodecl> end -- Returns a ray trace from mouse position
-function Raylib.GetCameraMatrix(camera: Camera): Matrix <cimport'GetCameraMatrix', nodecl> end -- Returns camera transform matrix (view matrix)
-function Raylib.GetCameraMatrix2D(camera: Camera2D): Matrix <cimport'GetCameraMatrix2D', nodecl> end -- Returns camera 2d transform matrix
-function Raylib.GetWorldToScreen(position: Vector3, camera: Camera): Vector2 <cimport'GetWorldToScreen', nodecl> end -- Returns the screen space position for a 3d world space position
-function Raylib.GetWorldToScreenEx(position: Vector3, camera: Camera, width: cint, height: cint): Vector2 <cimport'GetWorldToScreenEx', nodecl> end -- Returns size position for a 3d world space position
-function Raylib.GetWorldToScreen2D(position: Vector2, camera: Camera2D): Vector2 <cimport'GetWorldToScreen2D', nodecl> end -- Returns the screen space position for a 2d camera world space position
-function Raylib.GetScreenToWorld2D(position: Vector2, camera: Camera2D): Vector2 <cimport'GetScreenToWorld2D', nodecl> end -- Returns the world space position for a 2d camera screen space position
+function Raylib.GetMouseRay(mousePosition: Vector2, camera: Camera): Ray <cimport'GetMouseRay', cinclude'<raylib.h>', nodecl> end -- Returns a ray trace from mouse position
+function Raylib.GetCameraMatrix(camera: Camera): Matrix <cimport'GetCameraMatrix', cinclude'<raylib.h>', nodecl> end -- Returns camera transform matrix (view matrix)
+function Raylib.GetCameraMatrix2D(camera: Camera2D): Matrix <cimport'GetCameraMatrix2D', cinclude'<raylib.h>', nodecl> end -- Returns camera 2d transform matrix
+function Raylib.GetWorldToScreen(position: Vector3, camera: Camera): Vector2 <cimport'GetWorldToScreen', cinclude'<raylib.h>', nodecl> end -- Returns the screen space position for a 3d world space position
+function Raylib.GetWorldToScreenEx(position: Vector3, camera: Camera, width: cint, height: cint): Vector2 <cimport'GetWorldToScreenEx', cinclude'<raylib.h>', nodecl> end -- Returns size position for a 3d world space position
+function Raylib.GetWorldToScreen2D(position: Vector2, camera: Camera2D): Vector2 <cimport'GetWorldToScreen2D', cinclude'<raylib.h>', nodecl> end -- Returns the screen space position for a 2d camera world space position
+function Raylib.GetScreenToWorld2D(position: Vector2, camera: Camera2D): Vector2 <cimport'GetScreenToWorld2D', cinclude'<raylib.h>', nodecl> end -- Returns the world space position for a 2d camera screen space position
 
 -- Timing-related functions
-function Raylib.SetTargetFPS(fps: cint): void <cimport'SetTargetFPS', nodecl> end -- Set target FPS (maximum)
-function Raylib.GetFPS(): cint <cimport'GetFPS', nodecl> end -- Returns current FPS
-function Raylib.GetFrameTime(): float32 <cimport'GetFrameTime', nodecl> end -- Returns time in seconds for last frame drawn
-function Raylib.GetTime(): float64 <cimport'GetTime', nodecl> end -- Returns elapsed time in seconds since InitWindow()
+function Raylib.SetTargetFPS(fps: cint): void <cimport'SetTargetFPS', cinclude'<raylib.h>', nodecl> end -- Set target FPS (maximum)
+function Raylib.GetFPS(): cint <cimport'GetFPS', cinclude'<raylib.h>', nodecl> end -- Returns current FPS
+function Raylib.GetFrameTime(): float32 <cimport'GetFrameTime', cinclude'<raylib.h>', nodecl> end -- Returns time in seconds for last frame drawn
+function Raylib.GetTime(): float64 <cimport'GetTime', cinclude'<raylib.h>', nodecl> end -- Returns elapsed time in seconds since InitWindow()
 
 -- Color-related functions
-function Raylib.ColorToInt(color: Color): cint <cimport'ColorToInt', nodecl> end -- Returns hexadecimal value for a Color
-function Raylib.ColorNormalize(color: Color): Vector4 <cimport'ColorNormalize', nodecl> end -- Returns color normalized as float [0..1]
-function Raylib.ColorFromNormalized(normalized: Vector4): Color <cimport'ColorFromNormalized', nodecl> end -- Returns color from normalized values [0..1]
-function Raylib.ColorToHSV(color: Color): Vector3 <cimport'ColorToHSV', nodecl> end -- Returns HSV values for a Color
-function Raylib.ColorFromHSV(hsv: Vector3): Color <cimport'ColorFromHSV', nodecl> end -- Returns a Color from HSV values
-function Raylib.GetColor(hexValue: cint): Color <cimport'GetColor', nodecl> end -- Returns a Color struct from hexadecimal value
-function Raylib.Fade(color: Color, alpha: float32): Color <cimport'Fade', nodecl> end -- Color fade-in or fade-out, alpha goes from 0.0f to 1.0f
+function Raylib.ColorToInt(color: Color): cint <cimport'ColorToInt', cinclude'<raylib.h>', nodecl> end -- Returns hexadecimal value for a Color
+function Raylib.ColorNormalize(color: Color): Vector4 <cimport'ColorNormalize', cinclude'<raylib.h>', nodecl> end -- Returns color normalized as float [0..1]
+function Raylib.ColorFromNormalized(normalized: Vector4): Color <cimport'ColorFromNormalized', cinclude'<raylib.h>', nodecl> end -- Returns color from normalized values [0..1]
+function Raylib.ColorToHSV(color: Color): Vector3 <cimport'ColorToHSV', cinclude'<raylib.h>', nodecl> end -- Returns HSV values for a Color
+function Raylib.ColorFromHSV(hsv: Vector3): Color <cimport'ColorFromHSV', cinclude'<raylib.h>', nodecl> end -- Returns a Color from HSV values
+function Raylib.GetColor(hexValue: cint): Color <cimport'GetColor', cinclude'<raylib.h>', nodecl> end -- Returns a Color struct from hexadecimal value
+function Raylib.Fade(color: Color, alpha: float32): Color <cimport'Fade', cinclude'<raylib.h>', nodecl> end -- Color fade-in or fade-out, alpha goes from 0.0f to 1.0f
 
 -- Misc. functions
-function Raylib.SetConfigFlags(flags: cuint): void <cimport'SetConfigFlags', nodecl> end -- Setup window configuration flags (view FLAGS)
-function Raylib.SetTraceLogLevel(logType: cint): void <cimport'SetTraceLogLevel', nodecl> end -- Set the current threshold (minimum) log level
-function Raylib.SetTraceLogExit(logType: cint): void <cimport'SetTraceLogExit', nodecl> end -- Set the exit threshold (minimum) log level
-function Raylib.SetTraceLogCallback(callback: TraceLogCallback): void <cimport'SetTraceLogCallback', nodecl> end -- Set a trace log callback to enable custom logging
-function Raylib.TraceLog(logType: cint, text: cstring, ...): void <cimport'TraceLog', nodecl> end -- Show trace log messages (LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERROR)
-function Raylib.TakeScreenshot(fileName: cstring): void <cimport'TakeScreenshot', nodecl> end -- Takes a screenshot of current screen (saved a .png)
-function Raylib.GetRandomValue(min: cint, max: cint): cint <cimport'GetRandomValue', nodecl> end -- Returns a random value between min and max (both included)
+function Raylib.SetConfigFlags(flags: cuint): void <cimport'SetConfigFlags', cinclude'<raylib.h>', nodecl> end -- Setup window configuration flags (view FLAGS)
+function Raylib.SetTraceLogLevel(logType: cint): void <cimport'SetTraceLogLevel', cinclude'<raylib.h>', nodecl> end -- Set the current threshold (minimum) log level
+function Raylib.SetTraceLogExit(logType: cint): void <cimport'SetTraceLogExit', cinclude'<raylib.h>', nodecl> end -- Set the exit threshold (minimum) log level
+-- function Raylib.SetTraceLogCallback(callback: TraceLogCallback): void <cimport'SetTraceLogCallback', cinclude'<raylib.h>', nodecl> end -- Set a trace log callback to enable custom logging
+function Raylib.TraceLog(logType: cint, text: cstring, ...: cvarargs): void <cimport'TraceLog', cinclude'<raylib.h>', nodecl> end -- Show trace log messages (LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERROR)
+function Raylib.TakeScreenshot(fileName: cstring): void <cimport'TakeScreenshot', cinclude'<raylib.h>', nodecl> end -- Takes a screenshot of current screen (saved a .png)
+function Raylib.GetRandomValue(min: cint, max: cint): cint <cimport'GetRandomValue', cinclude'<raylib.h>', nodecl> end -- Returns a random value between min and max (both included)
 
 -- Files management functions
-function Raylib.LoadFileData(fileName: cstring, bytesRead: cuint*): cuchar[0]* <cimport'LoadFileData', nodecl> end -- Load file data as byte array (read)
-function Raylib.SaveFileData(fileName: cstring, data: pointer, bytesToWrite: cuint): void <cimport'SaveFileData', nodecl> end -- Save data to file from byte array (write)
-function Raylib.LoadFileText(fileName: cstring): cstring <cimport'LoadFileText', nodecl> end -- Load text data from file (read), returns a '\0' terminated string
-function Raylib.SaveFileText(fileName: cstring, text: cstring): void <cimport'SaveFileText', nodecl> end -- Save text data to file (write), string must be '\0' terminated
-function Raylib.FileExists(fileName: cstring): boolean <cimport'FileExists', nodecl> end -- Check if file exists
-function Raylib.IsFileExtension(fileName: cstring, ext: cstring): boolean <cimport'IsFileExtension', nodecl> end -- Check file extension
-function Raylib.DirectoryExists(dirPath: cstring): boolean <cimport'DirectoryExists', nodecl> end -- Check if a directory path exists
-function Raylib.GetExtension(fileName: cstring): cstring <cimport'GetExtension', nodecl> end -- Get pointer to extension for a filename string
-function Raylib.GetFileName(filePath: cstring): cstring <cimport'GetFileName', nodecl> end -- Get pointer to filename for a path string
-function Raylib.GetFileNameWithoutExt(filePath: cstring): cstring <cimport'GetFileNameWithoutExt', nodecl> end -- Get filename string without extension (uses static string)
-function Raylib.GetDirectoryPath(filePath: cstring): cstring <cimport'GetDirectoryPath', nodecl> end -- Get full path for a given fileName with path (uses static string)
-function Raylib.GetPrevDirectoryPath(dirPath: cstring): cstring <cimport'GetPrevDirectoryPath', nodecl> end -- Get previous directory path for a given path (uses static string)
-function Raylib.GetWorkingDirectory(): cstring <cimport'GetWorkingDirectory', nodecl> end -- Get current working directory (uses static string)
-function Raylib.GetDirectoryFiles(dirPath: cstring, count: cint*): cstring[0]* <cimport'GetDirectoryFiles', nodecl> end -- Get filenames in a directory path (memory should be freed)
-function Raylib.ClearDirectoryFiles(): void <cimport'ClearDirectoryFiles', nodecl> end -- Clear directory files paths buffers (free memory)
-function Raylib.ChangeDirectory(dir: cstring): boolean <cimport'ChangeDirectory', nodecl> end -- Change working directory, returns true if success
-function Raylib.IsFileDropped(): boolean <cimport'IsFileDropped', nodecl> end -- Check if a file has been dropped into window
-function Raylib.GetDroppedFiles(count: cint*): cstring[0]* <cimport'GetDroppedFiles', nodecl> end -- Get dropped files names (memory should be freed)
-function Raylib.ClearDroppedFiles(): void <cimport'ClearDroppedFiles', nodecl> end -- Clear dropped files paths buffer (free memory)
-function Raylib.GetFileModTime(fileName: cstring): clong <cimport'GetFileModTime', nodecl> end -- Get file modification time (last write time)
+function Raylib.LoadFileData(fileName: cstring, bytesRead: *cuint): *[0]cuchar <cimport'LoadFileData', cinclude'<raylib.h>', nodecl> end -- Load file data as byte array (read)
+function Raylib.SaveFileData(fileName: cstring, data: pointer, bytesToWrite: cuint): void <cimport'SaveFileData', cinclude'<raylib.h>', nodecl> end -- Save data to file from byte array (write)
+function Raylib.LoadFileText(fileName: cstring): cstring <cimport'LoadFileText', cinclude'<raylib.h>', nodecl> end -- Load text data from file (read), returns a '\0' terminated string
+function Raylib.SaveFileText(fileName: cstring, text: cstring): void <cimport'SaveFileText', cinclude'<raylib.h>', nodecl> end -- Save text data to file (write), string must be '\0' terminated
+function Raylib.FileExists(fileName: cstring): boolean <cimport'FileExists', cinclude'<raylib.h>', nodecl> end -- Check if file exists
+function Raylib.IsFileExtension(fileName: cstring, ext: cstring): boolean <cimport'IsFileExtension', cinclude'<raylib.h>', nodecl> end -- Check file extension
+function Raylib.DirectoryExists(dirPath: cstring): boolean <cimport'DirectoryExists', cinclude'<raylib.h>', nodecl> end -- Check if a directory path exists
+function Raylib.GetExtension(fileName: cstring): cstring <cimport'GetExtension', cinclude'<raylib.h>', nodecl> end -- Get pointer to extension for a filename string
+function Raylib.GetFileName(filePath: cstring): cstring <cimport'GetFileName', cinclude'<raylib.h>', nodecl> end -- Get pointer to filename for a path string
+function Raylib.GetFileNameWithoutExt(filePath: cstring): cstring <cimport'GetFileNameWithoutExt', cinclude'<raylib.h>', nodecl> end -- Get filename string without extension (uses static string)
+function Raylib.GetDirectoryPath(filePath: cstring): cstring <cimport'GetDirectoryPath', cinclude'<raylib.h>', nodecl> end -- Get full path for a given fileName with path (uses static string)
+function Raylib.GetPrevDirectoryPath(dirPath: cstring): cstring <cimport'GetPrevDirectoryPath', cinclude'<raylib.h>', nodecl> end -- Get previous directory path for a given path (uses static string)
+function Raylib.GetWorkingDirectory(): cstring <cimport'GetWorkingDirectory', cinclude'<raylib.h>', nodecl> end -- Get current working directory (uses static string)
+function Raylib.GetDirectoryFiles(dirPath: cstring, count: *cint): *[0]cstring <cimport'GetDirectoryFiles', cinclude'<raylib.h>', nodecl> end -- Get filenames in a directory path (memory should be freed)
+function Raylib.ClearDirectoryFiles(): void <cimport'ClearDirectoryFiles', cinclude'<raylib.h>', nodecl> end -- Clear directory files paths buffers (free memory)
+function Raylib.ChangeDirectory(dir: cstring): boolean <cimport'ChangeDirectory', cinclude'<raylib.h>', nodecl> end -- Change working directory, returns true if success
+function Raylib.IsFileDropped(): boolean <cimport'IsFileDropped', cinclude'<raylib.h>', nodecl> end -- Check if a file has been dropped into window
+function Raylib.GetDroppedFiles(count: *cint): *[0]cstring <cimport'GetDroppedFiles', cinclude'<raylib.h>', nodecl> end -- Get dropped files names (memory should be freed)
+function Raylib.ClearDroppedFiles(): void <cimport'ClearDroppedFiles', cinclude'<raylib.h>', nodecl> end -- Clear dropped files paths buffer (free memory)
+function Raylib.GetFileModTime(fileName: cstring): clong <cimport'GetFileModTime', cinclude'<raylib.h>', nodecl> end -- Get file modification time (last write time)
 
-function Raylib.CompressData(data: cuchar[0]*, dataLength: cint, compDataLength: cint*): cuchar[0]* <cimport'CompressData', nodecl> end -- Compress data (DEFLATE algorythm)
-function Raylib.DecompressData(compData: cuchar[0]*, compDataLength: cint, dataLength: cint*): cuchar[0]* <cimport'DecompressData', nodecl> end -- Decompress data (DEFLATE algorythm)
+function Raylib.CompressData(data: *[0]cuchar, dataLength: cint, compDataLength: *cint): *[0]cuchar <cimport'CompressData', cinclude'<raylib.h>', nodecl> end -- Compress data (DEFLATE algorythm)
+function Raylib.DecompressData(compData: *[0]cuchar, compDataLength: cint, dataLength: *cint): *[0]cuchar <cimport'DecompressData', cinclude'<raylib.h>', nodecl> end -- Decompress data (DEFLATE algorythm)
 
 -- Persistent storage management
-function Raylib.SaveStorageValue(position: cuint, value: cint): void <cimport'SaveStorageValue', nodecl> end -- Save integer value to storage file (to defined position)
-function Raylib.LoadStorageValue(position: cuint): cint <cimport'LoadStorageValue', nodecl> end -- Load integer value from storage file (from defined position)
+function Raylib.SaveStorageValue(position: cuint, value: cint): void <cimport'SaveStorageValue', cinclude'<raylib.h>', nodecl> end -- Save integer value to storage file (to defined position)
+function Raylib.LoadStorageValue(position: cuint): cint <cimport'LoadStorageValue', cinclude'<raylib.h>', nodecl> end -- Load integer value from storage file (from defined position)
 
-function Raylib.OpenURL(url: cstring): void <cimport'OpenURL', nodecl> end -- Open URL with default system browser (if available)
+function Raylib.OpenURL(url: cstring): void <cimport'OpenURL', cinclude'<raylib.h>', nodecl> end -- Open URL with default system browser (if available)
 
 -- ------------------------------------------------------------------------------------
 -- Input Handling Functions (Module: core)
 -- ------------------------------------------------------------------------------------
 
 -- Input-related functions: keyboard
-function Raylib.IsKeyPressed(key: cint): boolean <cimport'IsKeyPressed', nodecl> end -- Detect if a key has been pressed once
-function Raylib.IsKeyDown(key: cint): boolean <cimport'IsKeyDown', nodecl> end -- Detect if a key is being pressed
-function Raylib.IsKeyReleased(key: cint): boolean <cimport'IsKeyReleased', nodecl> end -- Detect if a key has been released once
-function Raylib.IsKeyUp(key: cint): boolean <cimport'IsKeyUp', nodecl> end -- Detect if a key is NOT being pressed
-function Raylib.SetExitKey(key: cint): void <cimport'SetExitKey', nodecl> end -- Set a custom key to exit program (default is ESC)
-function Raylib.GetKeyPressed(): cint <cimport'GetKeyPressed', nodecl> end -- Get key pressed, call it multiple times for chars queued
+function Raylib.IsKeyPressed(key: cint): boolean <cimport'IsKeyPressed', cinclude'<raylib.h>', nodecl> end -- Detect if a key has been pressed once
+function Raylib.IsKeyDown(key: cint): boolean <cimport'IsKeyDown', cinclude'<raylib.h>', nodecl> end -- Detect if a key is being pressed
+function Raylib.IsKeyReleased(key: cint): boolean <cimport'IsKeyReleased', cinclude'<raylib.h>', nodecl> end -- Detect if a key has been released once
+function Raylib.IsKeyUp(key: cint): boolean <cimport'IsKeyUp', cinclude'<raylib.h>', nodecl> end -- Detect if a key is NOT being pressed
+function Raylib.SetExitKey(key: cint): void <cimport'SetExitKey', cinclude'<raylib.h>', nodecl> end -- Set a custom key to exit program (default is ESC)
+function Raylib.GetKeyPressed(): cint <cimport'GetKeyPressed', cinclude'<raylib.h>', nodecl> end -- Get key pressed, call it multiple times for chars queued
 
 -- Input-related functions: gamepads
-function Raylib.IsGamepadAvailable(gamepad: cint): boolean <cimport'IsGamepadAvailable', nodecl> end -- Detect if a gamepad is available
-function Raylib.IsGamepadName(gamepad: cint, name: cstring): boolean <cimport'IsGamepadName', nodecl> end -- Check gamepad name (if available)
-function Raylib.GetGamepadName(gamepad: cint): cstring <cimport'GetGamepadName', nodecl> end -- Return gamepad internal name id
-function Raylib.IsGamepadButtonPressed(gamepad: cint, button: cint): boolean <cimport'IsGamepadButtonPressed', nodecl> end -- Detect if a gamepad button has been pressed once
-function Raylib.IsGamepadButtonDown(gamepad: cint, button: cint): boolean <cimport'IsGamepadButtonDown', nodecl> end -- Detect if a gamepad button is being pressed
-function Raylib.IsGamepadButtonReleased(gamepad: cint, button: cint): boolean <cimport'IsGamepadButtonReleased', nodecl> end -- Detect if a gamepad button has been released once
-function Raylib.IsGamepadButtonUp(gamepad: cint, button: cint): boolean <cimport'IsGamepadButtonUp', nodecl> end -- Detect if a gamepad button is NOT being pressed
-function Raylib.GetGamepadButtonPressed(): cint <cimport'GetGamepadButtonPressed', nodecl> end -- Get the last gamepad button pressed
-function Raylib.GetGamepadAxisCount(gamepad: cint): cint <cimport'GetGamepadAxisCount', nodecl> end -- Return gamepad axis count for a gamepad
-function Raylib.GetGamepadAxisMovement(gamepad: cint, axis: cint): float32 <cimport'GetGamepadAxisMovement', nodecl> end -- Return axis movement value for a gamepad axis
+function Raylib.IsGamepadAvailable(gamepad: cint): boolean <cimport'IsGamepadAvailable', cinclude'<raylib.h>', nodecl> end -- Detect if a gamepad is available
+function Raylib.IsGamepadName(gamepad: cint, name: cstring): boolean <cimport'IsGamepadName', cinclude'<raylib.h>', nodecl> end -- Check gamepad name (if available)
+function Raylib.GetGamepadName(gamepad: cint): cstring <cimport'GetGamepadName', cinclude'<raylib.h>', nodecl> end -- Return gamepad internal name id
+function Raylib.IsGamepadButtonPressed(gamepad: cint, button: cint): boolean <cimport'IsGamepadButtonPressed', cinclude'<raylib.h>', nodecl> end -- Detect if a gamepad button has been pressed once
+function Raylib.IsGamepadButtonDown(gamepad: cint, button: cint): boolean <cimport'IsGamepadButtonDown', cinclude'<raylib.h>', nodecl> end -- Detect if a gamepad button is being pressed
+function Raylib.IsGamepadButtonReleased(gamepad: cint, button: cint): boolean <cimport'IsGamepadButtonReleased', cinclude'<raylib.h>', nodecl> end -- Detect if a gamepad button has been released once
+function Raylib.IsGamepadButtonUp(gamepad: cint, button: cint): boolean <cimport'IsGamepadButtonUp', cinclude'<raylib.h>', nodecl> end -- Detect if a gamepad button is NOT being pressed
+function Raylib.GetGamepadButtonPressed(): cint <cimport'GetGamepadButtonPressed', cinclude'<raylib.h>', nodecl> end -- Get the last gamepad button pressed
+function Raylib.GetGamepadAxisCount(gamepad: cint): cint <cimport'GetGamepadAxisCount', cinclude'<raylib.h>', nodecl> end -- Return gamepad axis count for a gamepad
+function Raylib.GetGamepadAxisMovement(gamepad: cint, axis: cint): float32 <cimport'GetGamepadAxisMovement', cinclude'<raylib.h>', nodecl> end -- Return axis movement value for a gamepad axis
 
 -- Input-related functions: mouse
-function Raylib.IsMouseButtonPressed(button: cint): boolean <cimport'IsMouseButtonPressed', nodecl> end -- Detect if a mouse button has been pressed once
-function Raylib.IsMouseButtonDown(button: cint): boolean <cimport'IsMouseButtonDown', nodecl> end -- Detect if a mouse button is being pressed
-function Raylib.IsMouseButtonReleased(button: cint): boolean <cimport'IsMouseButtonReleased', nodecl> end -- Detect if a mouse button has been released once
-function Raylib.IsMouseButtonUp(button: cint): boolean <cimport'IsMouseButtonUp', nodecl> end -- Detect if a mouse button is NOT being pressed
-function Raylib.GetMouseX(): cint <cimport'GetMouseX', nodecl> end -- Returns mouse position X
-function Raylib.GetMouseY(): cint <cimport'GetMouseY', nodecl> end -- Returns mouse position Y
-function Raylib.GetMousePosition(): Vector2 <cimport'GetMousePosition', nodecl> end -- Returns mouse position XY
-function Raylib.SetMousePosition(x: cint, y: cint): void <cimport'SetMousePosition', nodecl> end -- Set mouse position XY
-function Raylib.SetMouseOffset(offsetX: cint, offsetY: cint): void <cimport'SetMouseOffset', nodecl> end -- Set mouse offset
-function Raylib.SetMouseScale(scaleX: float32, scaleY: float32): void <cimport'SetMouseScale', nodecl> end -- Set mouse scaling
-function Raylib.GetMouseWheelMove(): cint <cimport'GetMouseWheelMove', nodecl> end -- Returns mouse wheel movement Y
+function Raylib.IsMouseButtonPressed(button: cint): boolean <cimport'IsMouseButtonPressed', cinclude'<raylib.h>', nodecl> end -- Detect if a mouse button has been pressed once
+function Raylib.IsMouseButtonDown(button: cint): boolean <cimport'IsMouseButtonDown', cinclude'<raylib.h>', nodecl> end -- Detect if a mouse button is being pressed
+function Raylib.IsMouseButtonReleased(button: cint): boolean <cimport'IsMouseButtonReleased', cinclude'<raylib.h>', nodecl> end -- Detect if a mouse button has been released once
+function Raylib.IsMouseButtonUp(button: cint): boolean <cimport'IsMouseButtonUp', cinclude'<raylib.h>', nodecl> end -- Detect if a mouse button is NOT being pressed
+function Raylib.GetMouseX(): cint <cimport'GetMouseX', cinclude'<raylib.h>', nodecl> end -- Returns mouse position X
+function Raylib.GetMouseY(): cint <cimport'GetMouseY', cinclude'<raylib.h>', nodecl> end -- Returns mouse position Y
+function Raylib.GetMousePosition(): Vector2 <cimport'GetMousePosition', cinclude'<raylib.h>', nodecl> end -- Returns mouse position XY
+function Raylib.SetMousePosition(x: cint, y: cint): void <cimport'SetMousePosition', cinclude'<raylib.h>', nodecl> end -- Set mouse position XY
+function Raylib.SetMouseOffset(offsetX: cint, offsetY: cint): void <cimport'SetMouseOffset', cinclude'<raylib.h>', nodecl> end -- Set mouse offset
+function Raylib.SetMouseScale(scaleX: float32, scaleY: float32): void <cimport'SetMouseScale', cinclude'<raylib.h>', nodecl> end -- Set mouse scaling
+function Raylib.GetMouseWheelMove(): cint <cimport'GetMouseWheelMove', cinclude'<raylib.h>', nodecl> end -- Returns mouse wheel movement Y
 
 -- Input-related functions: touch
-function Raylib.GetTouchX(): cint <cimport'GetTouchX', nodecl> end -- Returns touch position X for touch point 0 (relative to screen size)
-function Raylib.GetTouchY(): cint <cimport'GetTouchY', nodecl> end -- Returns touch position Y for touch point 0 (relative to screen size)
-function Raylib.GetTouchPosition(index: cint): Vector2 <cimport'GetTouchPosition', nodecl> end -- Returns touch position XY for a touch point index (relative to screen size)
+function Raylib.GetTouchX(): cint <cimport'GetTouchX', cinclude'<raylib.h>', nodecl> end -- Returns touch position X for touch point 0 (relative to screen size)
+function Raylib.GetTouchY(): cint <cimport'GetTouchY', cinclude'<raylib.h>', nodecl> end -- Returns touch position Y for touch point 0 (relative to screen size)
+function Raylib.GetTouchPosition(index: cint): Vector2 <cimport'GetTouchPosition', cinclude'<raylib.h>', nodecl> end -- Returns touch position XY for a touch point index (relative to screen size)
 
 -- ------------------------------------------------------------------------------------
 -- Gestures and Touch Handling Functions (Module: gestures)
 -- ------------------------------------------------------------------------------------
-function Raylib.SetGesturesEnabled(gestureFlags: cuint): void <cimport'SetGesturesEnabled', nodecl> end -- Enable a set of gestures using flags
-function Raylib.IsGestureDetected(gesture: cint): boolean <cimport'IsGestureDetected', nodecl> end -- Check if a gesture have been detected
-function Raylib.GetGestureDetected(): cint <cimport'GetGestureDetected', nodecl> end -- Get latest detected gesture
-function Raylib.GetTouchPointsCount(): cint <cimport'GetTouchPointsCount', nodecl> end -- Get touch points count
-function Raylib.GetGestureHoldDuration(): float32 <cimport'GetGestureHoldDuration', nodecl> end -- Get gesture hold time in milliseconds
-function Raylib.GetGestureDragVector(): Vector2 <cimport'GetGestureDragVector', nodecl> end -- Get gesture drag vector
-function Raylib.GetGestureDragAngle(): float32 <cimport'GetGestureDragAngle', nodecl> end -- Get gesture drag angle
-function Raylib.GetGesturePinchVector(): Vector2 <cimport'GetGesturePinchVector', nodecl> end -- Get gesture pinch delta
-function Raylib.GetGesturePinchAngle(): float32 <cimport'GetGesturePinchAngle', nodecl> end -- Get gesture pinch angle
+function Raylib.SetGesturesEnabled(gestureFlags: cuint): void <cimport'SetGesturesEnabled', cinclude'<raylib.h>', nodecl> end -- Enable a set of gestures using flags
+function Raylib.IsGestureDetected(gesture: cint): boolean <cimport'IsGestureDetected', cinclude'<raylib.h>', nodecl> end -- Check if a gesture have been detected
+function Raylib.GetGestureDetected(): cint <cimport'GetGestureDetected', cinclude'<raylib.h>', nodecl> end -- Get latest detected gesture
+function Raylib.GetTouchPointsCount(): cint <cimport'GetTouchPointsCount', cinclude'<raylib.h>', nodecl> end -- Get touch points count
+function Raylib.GetGestureHoldDuration(): float32 <cimport'GetGestureHoldDuration', cinclude'<raylib.h>', nodecl> end -- Get gesture hold time in milliseconds
+function Raylib.GetGestureDragVector(): Vector2 <cimport'GetGestureDragVector', cinclude'<raylib.h>', nodecl> end -- Get gesture drag vector
+function Raylib.GetGestureDragAngle(): float32 <cimport'GetGestureDragAngle', cinclude'<raylib.h>', nodecl> end -- Get gesture drag angle
+function Raylib.GetGesturePinchVector(): Vector2 <cimport'GetGesturePinchVector', cinclude'<raylib.h>', nodecl> end -- Get gesture pinch delta
+function Raylib.GetGesturePinchAngle(): float32 <cimport'GetGesturePinchAngle', cinclude'<raylib.h>', nodecl> end -- Get gesture pinch angle
 
 -- ------------------------------------------------------------------------------------
 -- Camera System Functions (Module: camera)
 -- ------------------------------------------------------------------------------------
-function Raylib.SetCameraMode(camera: Camera, mode: cint): void <cimport'SetCameraMode', nodecl> end -- Set camera mode (multiple camera modes available)
-function Raylib.UpdateCamera(camera: Camera*): void <cimport'UpdateCamera', nodecl> end -- Update camera position for selected mode
+function Raylib.SetCameraMode(camera: Camera, mode: cint): void <cimport'SetCameraMode', cinclude'<raylib.h>', nodecl> end -- Set camera mode (multiple camera modes available)
+function Raylib.UpdateCamera(camera: *Camera): void <cimport'UpdateCamera', cinclude'<raylib.h>', nodecl> end -- Update camera position for selected mode
+function Camera.UpdateCamera(camera: *Camera): void <cimport'UpdateCamera', cinclude'<raylib.h>', nodecl> end -- Update camera position for selected mode
 
-function Raylib.SetCameraPanControl(panKey: cint): void <cimport'SetCameraPanControl', nodecl> end -- Set camera pan key to combine with mouse movement (free camera)
-function Raylib.SetCameraAltControl(altKey: cint): void <cimport'SetCameraAltControl', nodecl> end -- Set camera alt key to combine with mouse movement (free camera)
-function Raylib.SetCameraSmoothZoomControl(szKey: cint): void <cimport'SetCameraSmoothZoomControl', nodecl> end -- Set camera smooth zoom key to combine with mouse (free camera)
-function Raylib.SetCameraMoveControls(frontKey: cint, backKey: cint, rightKey: cint, leftKey: cint, upKey: cint, downKey: cint): void <cimport'SetCameraMoveControls', nodecl> end -- Set camera move controls (1st person and 3rd person cameras)
+
+function Raylib.SetCameraPanControl(panKey: cint): void <cimport'SetCameraPanControl', cinclude'<raylib.h>', nodecl> end -- Set camera pan key to combine with mouse movement (free camera)
+function Raylib.SetCameraAltControl(altKey: cint): void <cimport'SetCameraAltControl', cinclude'<raylib.h>', nodecl> end -- Set camera alt key to combine with mouse movement (free camera)
+function Raylib.SetCameraSmoothZoomControl(szKey: cint): void <cimport'SetCameraSmoothZoomControl', cinclude'<raylib.h>', nodecl> end -- Set camera smooth zoom key to combine with mouse (free camera)
+function Raylib.SetCameraMoveControls(frontKey: cint, backKey: cint, rightKey: cint, leftKey: cint, upKey: cint, downKey: cint): void <cimport'SetCameraMoveControls', cinclude'<raylib.h>', nodecl> end -- Set camera move controls (1st person and 3rd person cameras)
 
 -- ------------------------------------------------------------------------------------
 -- Basic Shapes Drawing Functions (Module: shapes)
 -- ------------------------------------------------------------------------------------
 
 -- Basic shapes drawing functions
-function Raylib.DrawPixel(posX: cint, posY: cint, color: Color): void <cimport'DrawPixel', nodecl> end -- Draw a pixel
-function Raylib.DrawPixelV(position: Vector2, color: Color): void <cimport'DrawPixelV', nodecl> end -- Draw a pixel (Vector version)
-function Raylib.DrawLine(startPosX: cint, startPosY: cint, endPosX: cint, endPosY: cint, color: Color): void <cimport'DrawLine', nodecl> end -- Draw a line
-function Raylib.DrawLineV(startPos: Vector2, endPos: Vector2, color: Color): void <cimport'DrawLineV', nodecl> end -- Draw a line (Vector version)
-function Raylib.DrawLineEx(startPos: Vector2, endPos: Vector2, thick: float32, color: Color): void <cimport'DrawLineEx', nodecl> end -- Draw a line defining thickness
-function Raylib.DrawLineBezier(startPos: Vector2, endPos: Vector2, thick: float32, color: Color): void <cimport'DrawLineBezier', nodecl> end -- Draw a line using cubic-bezier curves in-out
-function Raylib.DrawLineStrip(points: Vector2[0]*, numPoints: cint, color: Color): void <cimport'DrawLineStrip', nodecl> end -- Draw lines sequence
-function Raylib.DrawCircle(centerX: cint, centerY: cint, radius: float32, color: Color): void <cimport'DrawCircle', nodecl> end -- Draw a color-filled circle
-function Raylib.DrawCircleSector(center: Vector2, radius: float32, startAngle: cint, endAngle: cint, segments: cint, color: Color): void <cimport'DrawCircleSector', nodecl> end -- Draw a piece of a circle
-function Raylib.DrawCircleSectorLines(center: Vector2, radius: float32, startAngle: cint, endAngle: cint, segments: cint, color: Color): void <cimport'DrawCircleSectorLines', nodecl> end -- Draw circle sector outline
-function Raylib.DrawCircleGradient(centerX: cint, centerY: cint, radius: float32, color1: Color, color2: Color): void <cimport'DrawCircleGradient', nodecl> end -- Draw a gradient-filled circle
-function Raylib.DrawCircleV(center: Vector2, radius: float32, color: Color): void <cimport'DrawCircleV', nodecl> end -- Draw a color-filled circle (Vector version)
-function Raylib.DrawCircleLines(centerX: cint, centerY: cint, radius: float32, color: Color): void <cimport'DrawCircleLines', nodecl> end -- Draw circle outline
-function Raylib.DrawEllipse(centerX: cint, centerY: cint, radiusH: float32, radiusV: float32, color: Color): void <cimport'DrawEllipse', nodecl> end -- Draw ellipse
-function Raylib.DrawEllipseLines(centerX: cint, centerY: cint, radiusH: float32, radiusV: float32, color: Color): void <cimport'DrawEllipseLines', nodecl> end -- Draw ellipse outline
-function Raylib.DrawRing(center: Vector2, innerRadius: float32, outerRadius: float32, startAngle: cint, endAngle: cint, segments: cint, color: Color): void <cimport'DrawRing', nodecl> end -- Draw ring
-function Raylib.DrawRingLines(center: Vector2, innerRadius: float32, outerRadius: float32, startAngle: cint, endAngle: cint, segments: cint, color: Color): void <cimport'DrawRingLines', nodecl> end -- Draw ring outline
-function Raylib.DrawRectangle(posX: cint, posY: cint, width: cint, height: cint, color: Color): void <cimport'DrawRectangle', nodecl> end -- Draw a color-filled rectangle
-function Raylib.DrawRectangleV(position: Vector2, size: Vector2, color: Color): void <cimport'DrawRectangleV', nodecl> end -- Draw a color-filled rectangle (Vector version)
-function Raylib.DrawRectangleRec(rec: Rectangle, color: Color): void <cimport'DrawRectangleRec', nodecl> end -- Draw a color-filled rectangle
-function Raylib.DrawRectanglePro(rec: Rectangle, origin: Vector2, rotation: float32, color: Color): void <cimport'DrawRectanglePro', nodecl> end -- Draw a color-filled rectangle with pro parameters
-function Raylib.DrawRectangleGradientV(posX: cint, posY: cint, width: cint, height: cint, color1: Color, color2: Color): void <cimport'DrawRectangleGradientV', nodecl> end -- Draw a vertical-gradient-filled rectangle
-function Raylib.DrawRectangleGradientH(posX: cint, posY: cint, width: cint, height: cint, color1: Color, color2: Color): void <cimport'DrawRectangleGradientH', nodecl> end -- Draw a horizontal-gradient-filled rectangle
-function Raylib.DrawRectangleGradientEx(rec: Rectangle, col1: Color, col2: Color, col3: Color, col4: Color): void <cimport'DrawRectangleGradientEx', nodecl> end -- Draw a gradient-filled rectangle with custom vertex colors
-function Raylib.DrawRectangleLines(posX: cint, posY: cint, width: cint, height: cint, color: Color): void <cimport'DrawRectangleLines', nodecl> end -- Draw rectangle outline
-function Raylib.DrawRectangleLinesEx(rec: Rectangle, lineThick: cint, color: Color): void <cimport'DrawRectangleLinesEx', nodecl> end -- Draw rectangle outline with extended parameters
-function Raylib.DrawRectangleRounded(rec: Rectangle, roundness: float32, segments: cint, color: Color): void <cimport'DrawRectangleRounded', nodecl> end -- Draw rectangle with rounded edges
-function Raylib.DrawRectangleRoundedLines(rec: Rectangle, roundness: float32, segments: cint, lineThick: cint, color: Color): void <cimport'DrawRectangleRoundedLines', nodecl> end -- Draw rectangle with rounded edges outline
-function Raylib.DrawTriangle(v1: Vector2, v2: Vector2, v3: Vector2, color: Color): void <cimport'DrawTriangle', nodecl> end -- Draw a color-filled triangle (vertex in counter-clockwise order!)
-function Raylib.DrawTriangleLines(v1: Vector2, v2: Vector2, v3: Vector2, color: Color): void <cimport'DrawTriangleLines', nodecl> end -- Draw triangle outline (vertex in counter-clockwise order!)
-function Raylib.DrawTriangleFan(points: Vector2[0]*, numPoints: cint, color: Color): void <cimport'DrawTriangleFan', nodecl> end -- Draw a triangle fan defined by points (first vertex is the center)
-function Raylib.DrawTriangleStrip(points: Vector2[0]*, pointsCount: cint, color: Color): void <cimport'DrawTriangleStrip', nodecl> end -- Draw a triangle strip defined by points
-function Raylib.DrawPoly(center: Vector2, sides: cint, radius: float32, rotation: float32, color: Color): void <cimport'DrawPoly', nodecl> end -- Draw a regular polygon (Vector version)
-function Raylib.DrawPolyLines(center: Vector2, sides: cint, radius: float32, rotation: float32, color: Color): void <cimport'DrawPolyLines', nodecl> end -- Draw a polygon outline of n sides
+function Raylib.DrawPixel(posX: cint, posY: cint, color: Color): void <cimport'DrawPixel', cinclude'<raylib.h>', nodecl> end -- Draw a pixel
+function Raylib.DrawPixelV(position: Vector2, color: Color): void <cimport'DrawPixelV', cinclude'<raylib.h>', nodecl> end -- Draw a pixel (Vector version)
+function Raylib.DrawLine(startPosX: cint, startPosY: cint, endPosX: cint, endPosY: cint, color: Color): void <cimport'DrawLine', cinclude'<raylib.h>', nodecl> end -- Draw a line
+function Raylib.DrawLineV(startPos: Vector2, endPos: Vector2, color: Color): void <cimport'DrawLineV', cinclude'<raylib.h>', nodecl> end -- Draw a line (Vector version)
+function Raylib.DrawLineEx(startPos: Vector2, endPos: Vector2, thick: float32, color: Color): void <cimport'DrawLineEx', cinclude'<raylib.h>', nodecl> end -- Draw a line defining thickness
+function Raylib.DrawLineBezier(startPos: Vector2, endPos: Vector2, thick: float32, color: Color): void <cimport'DrawLineBezier', cinclude'<raylib.h>', nodecl> end -- Draw a line using cubic-bezier curves in-out
+function Raylib.DrawLineStrip(points: *[0]Vector2, numPoints: cint, color: Color): void <cimport'DrawLineStrip', cinclude'<raylib.h>', nodecl> end -- Draw lines sequence
+function Raylib.DrawCircle(centerX: cint, centerY: cint, radius: float32, color: Color): void <cimport'DrawCircle', cinclude'<raylib.h>', nodecl> end -- Draw a color-filled circle
+function Raylib.DrawCircleSector(center: Vector2, radius: float32, startAngle: cint, endAngle: cint, segments: cint, color: Color): void <cimport'DrawCircleSector', cinclude'<raylib.h>', nodecl> end -- Draw a piece of a circle
+function Raylib.DrawCircleSectorLines(center: Vector2, radius: float32, startAngle: cint, endAngle: cint, segments: cint, color: Color): void <cimport'DrawCircleSectorLines', cinclude'<raylib.h>', nodecl> end -- Draw circle sector outline
+function Raylib.DrawCircleGradient(centerX: cint, centerY: cint, radius: float32, color1: Color, color2: Color): void <cimport'DrawCircleGradient', cinclude'<raylib.h>', nodecl> end -- Draw a gradient-filled circle
+function Raylib.DrawCircleV(center: Vector2, radius: float32, color: Color): void <cimport'DrawCircleV', cinclude'<raylib.h>', nodecl> end -- Draw a color-filled circle (Vector version)
+function Raylib.DrawCircleLines(centerX: cint, centerY: cint, radius: float32, color: Color): void <cimport'DrawCircleLines', cinclude'<raylib.h>', nodecl> end -- Draw circle outline
+function Raylib.DrawEllipse(centerX: cint, centerY: cint, radiusH: float32, radiusV: float32, color: Color): void <cimport'DrawEllipse', cinclude'<raylib.h>', nodecl> end -- Draw ellipse
+function Raylib.DrawEllipseLines(centerX: cint, centerY: cint, radiusH: float32, radiusV: float32, color: Color): void <cimport'DrawEllipseLines', cinclude'<raylib.h>', nodecl> end -- Draw ellipse outline
+function Raylib.DrawRing(center: Vector2, innerRadius: float32, outerRadius: float32, startAngle: cint, endAngle: cint, segments: cint, color: Color): void <cimport'DrawRing', cinclude'<raylib.h>', nodecl> end -- Draw ring
+function Raylib.DrawRingLines(center: Vector2, innerRadius: float32, outerRadius: float32, startAngle: cint, endAngle: cint, segments: cint, color: Color): void <cimport'DrawRingLines', cinclude'<raylib.h>', nodecl> end -- Draw ring outline
+function Raylib.DrawRectangle(posX: cint, posY: cint, width: cint, height: cint, color: Color): void <cimport'DrawRectangle', cinclude'<raylib.h>', nodecl> end -- Draw a color-filled rectangle
+function Raylib.DrawRectangleV(position: Vector2, size: Vector2, color: Color): void <cimport'DrawRectangleV', cinclude'<raylib.h>', nodecl> end -- Draw a color-filled rectangle (Vector version)
+function Raylib.DrawRectangleRec(rec: Rectangle, color: Color): void <cimport'DrawRectangleRec', cinclude'<raylib.h>', nodecl> end -- Draw a color-filled rectangle
+function Raylib.DrawRectanglePro(rec: Rectangle, origin: Vector2, rotation: float32, color: Color): void <cimport'DrawRectanglePro', cinclude'<raylib.h>', nodecl> end -- Draw a color-filled rectangle with pro parameters
+function Raylib.DrawRectangleGradientV(posX: cint, posY: cint, width: cint, height: cint, color1: Color, color2: Color): void <cimport'DrawRectangleGradientV', cinclude'<raylib.h>', nodecl> end -- Draw a vertical-gradient-filled rectangle
+function Raylib.DrawRectangleGradientH(posX: cint, posY: cint, width: cint, height: cint, color1: Color, color2: Color): void <cimport'DrawRectangleGradientH', cinclude'<raylib.h>', nodecl> end -- Draw a horizontal-gradient-filled rectangle
+function Raylib.DrawRectangleGradientEx(rec: Rectangle, col1: Color, col2: Color, col3: Color, col4: Color): void <cimport'DrawRectangleGradientEx', cinclude'<raylib.h>', nodecl> end -- Draw a gradient-filled rectangle with custom vertex colors
+function Raylib.DrawRectangleLines(posX: cint, posY: cint, width: cint, height: cint, color: Color): void <cimport'DrawRectangleLines', cinclude'<raylib.h>', nodecl> end -- Draw rectangle outline
+function Raylib.DrawRectangleLinesEx(rec: Rectangle, lineThick: cint, color: Color): void <cimport'DrawRectangleLinesEx', cinclude'<raylib.h>', nodecl> end -- Draw rectangle outline with extended parameters
+function Raylib.DrawRectangleRounded(rec: Rectangle, roundness: float32, segments: cint, color: Color): void <cimport'DrawRectangleRounded', cinclude'<raylib.h>', nodecl> end -- Draw rectangle with rounded edges
+function Raylib.DrawRectangleRoundedLines(rec: Rectangle, roundness: float32, segments: cint, lineThick: cint, color: Color): void <cimport'DrawRectangleRoundedLines', cinclude'<raylib.h>', nodecl> end -- Draw rectangle with rounded edges outline
+function Raylib.DrawTriangle(v1: Vector2, v2: Vector2, v3: Vector2, color: Color): void <cimport'DrawTriangle', cinclude'<raylib.h>', nodecl> end -- Draw a color-filled triangle (vertex in counter-clockwise order!)
+function Raylib.DrawTriangleLines(v1: Vector2, v2: Vector2, v3: Vector2, color: Color): void <cimport'DrawTriangleLines', cinclude'<raylib.h>', nodecl> end -- Draw triangle outline (vertex in counter-clockwise order!)
+function Raylib.DrawTriangleFan(points: *Vector2, numPoints: cint, color: Color): void <cimport'DrawTriangleFan', cinclude'<raylib.h>', nodecl> end -- Draw a triangle fan defined by points (first vertex is the center)
+function Raylib.DrawTriangleStrip(points: *Vector2, pointsCount: cint, color: Color): void <cimport'DrawTriangleStrip', cinclude'<raylib.h>', nodecl> end -- Draw a triangle strip defined by points
+function Raylib.DrawPoly(center: Vector2, sides: cint, radius: float32, rotation: float32, color: Color): void <cimport'DrawPoly', cinclude'<raylib.h>', nodecl> end -- Draw a regular polygon (Vector version)
+function Raylib.DrawPolyLines(center: Vector2, sides: cint, radius: float32, rotation: float32, color: Color): void <cimport'DrawPolyLines', cinclude'<raylib.h>', nodecl> end -- Draw a polygon outline of n sides
 
 -- Basic shapes collision detection functions
-function Raylib.CheckCollisionRecs(rec1: Rectangle, rec2: Rectangle): boolean <cimport'CheckCollisionRecs', nodecl> end -- Check collision between two rectangles
-function Raylib.CheckCollisionCircles(center1: Vector2, radius1: float32, center2: Vector2, radius2: float32): boolean <cimport'CheckCollisionCircles', nodecl> end -- Check collision between two circles
-function Raylib.CheckCollisionCircleRec(center: Vector2, radius: float32, rec: Rectangle): boolean <cimport'CheckCollisionCircleRec', nodecl> end -- Check collision between circle and rectangle
-function Raylib.GetCollisionRec(rec1: Rectangle, rec2: Rectangle): Rectangle <cimport'GetCollisionRec', nodecl> end -- Get collision rectangle for two rectangles collision
-function Raylib.CheckCollisionPointRec(point: Vector2, rec: Rectangle): boolean <cimport'CheckCollisionPointRec', nodecl> end -- Check if point is inside rectangle
-function Raylib.CheckCollisionPointCircle(point: Vector2, center: Vector2, radius: float32): boolean <cimport'CheckCollisionPointCircle', nodecl> end -- Check if point is inside circle
-function Raylib.CheckCollisionPointTriangle(point: Vector2, p1: Vector2, p2: Vector2, p3: Vector2): boolean <cimport'CheckCollisionPointTriangle', nodecl> end -- Check if point is inside a triangle
+function Raylib.CheckCollisionRecs(rec1: Rectangle, rec2: Rectangle): boolean <cimport'CheckCollisionRecs', cinclude'<raylib.h>', nodecl> end -- Check collision between two rectangles
+function Raylib.CheckCollisionCircles(center1: Vector2, radius1: float32, center2: Vector2, radius2: float32): boolean <cimport'CheckCollisionCircles', cinclude'<raylib.h>', nodecl> end -- Check collision between two circles
+function Raylib.CheckCollisionCircleRec(center: Vector2, radius: float32, rec: Rectangle): boolean <cimport'CheckCollisionCircleRec', cinclude'<raylib.h>', nodecl> end -- Check collision between circle and rectangle
+function Raylib.GetCollisionRec(rec1: Rectangle, rec2: Rectangle): Rectangle <cimport'GetCollisionRec', cinclude'<raylib.h>', nodecl> end -- Get collision rectangle for two rectangles collision
+function Raylib.CheckCollisionPointRec(point: Vector2, rec: Rectangle): boolean <cimport'CheckCollisionPointRec', cinclude'<raylib.h>', nodecl> end -- Check if point is inside rectangle
+function Raylib.CheckCollisionPointCircle(point: Vector2, center: Vector2, radius: float32): boolean <cimport'CheckCollisionPointCircle', cinclude'<raylib.h>', nodecl> end -- Check if point is inside circle
+function Raylib.CheckCollisionPointTriangle(point: Vector2, p1: Vector2, p2: Vector2, p3: Vector2): boolean <cimport'CheckCollisionPointTriangle', cinclude'<raylib.h>', nodecl> end -- Check if point is inside a triangle
 
 -- ------------------------------------------------------------------------------------
 -- Texture Loading and Drawing Functions (Module: textures)
@@ -993,175 +989,259 @@ function Raylib.CheckCollisionPointTriangle(point: Vector2, p1: Vector2, p2: Vec
 
 -- Image loading functions
 -- NOTE: This functions do not require GPU access
-function Raylib.LoadImage(fileName: cstring): Image <cimport'LoadImage', nodecl> end -- Load image from file into CPU memory (RAM)
-function Raylib.LoadImageEx(pixels: Color[0]*, width: cint, height: cint): Image <cimport'LoadImageEx', nodecl> end -- Load image from Color array data (RGBA - 32bit)
-function Raylib.LoadImagePro(data: pointer, width: cint, height: cint, format: cint): Image <cimport'LoadImagePro', nodecl> end -- Load image from raw data with parameters
-function Raylib.LoadImageRaw(fileName: cstring, width: cint, height: cint, format: cint, headerSize: cint): Image <cimport'LoadImageRaw', nodecl> end -- Load image from RAW file data
-function Raylib.UnloadImage(image: Image): void <cimport'UnloadImage', nodecl> end -- Unload image from CPU memory (RAM)
-function Raylib.ExportImage(image: Image, fileName: cstring): void <cimport'ExportImage', nodecl> end -- Export image data to file
-function Raylib.ExportImageAsCode(image: Image, fileName: cstring): void <cimport'ExportImageAsCode', nodecl> end -- Export image as code file defining an array of bytes
-function Raylib.GetImageData(image: Image): Color[0]* <cimport'GetImageData', nodecl> end -- Get pixel data from image as a Color struct array
-function Raylib.GetImageDataNormalized(image: Image): Vector4[0]* <cimport'GetImageDataNormalized', nodecl> end -- Get pixel data from image as Vector4 array (float normalized)
+function Raylib.LoadImage(fileName: cstring): Image <cimport'LoadImage', cinclude'<raylib.h>', nodecl> end -- Load image from file into CPU memory (RAM)
+function Raylib.LoadImageEx(pixels: *[0]Color, width: cint, height: cint): Image <cimport'LoadImageEx', cinclude'<raylib.h>', nodecl> end -- Load image from Color array data (RGBA - 32bit)
+function Raylib.LoadImagePro(data: pointer, width: cint, height: cint, format: cint): Image <cimport'LoadImagePro', cinclude'<raylib.h>', nodecl> end -- Load image from raw data with parameters
+function Raylib.LoadImageRaw(fileName: cstring, width: cint, height: cint, format: cint, headerSize: cint): Image <cimport'LoadImageRaw', cinclude'<raylib.h>', nodecl> end -- Load image from RAW file data
+function Raylib.UnloadImage(image: Image): void <cimport'UnloadImage', cinclude'<raylib.h>', nodecl> end -- Unload image from CPU memory (RAM)
+function Raylib.ExportImage(image: Image, fileName: cstring): void <cimport'ExportImage', cinclude'<raylib.h>', nodecl> end -- Export image data to file
+function Raylib.ExportImageAsCode(image: Image, fileName: cstring): void <cimport'ExportImageAsCode', cinclude'<raylib.h>', nodecl> end -- Export image as code file defining an array of bytes
+function Raylib.GetImageData(image: Image): *[0]Color <cimport'GetImageData', cinclude'<raylib.h>', nodecl> end -- Get pixel data from image as a Color struct array
+function Raylib.GetImageDataNormalized(image: Image): *[0]Vector4 <cimport'GetImageDataNormalized', cinclude'<raylib.h>', nodecl> end -- Get pixel data from image as Vector4 array (float normalized)
 
 -- Image generation functions
-function Raylib.GenImageColor(width: cint, height: cint, color: Color): Image <cimport'GenImageColor', nodecl> end -- Generate image: plain color
-function Raylib.GenImageGradientV(width: cint, height: cint, top: Color, bottom: Color): Image <cimport'GenImageGradientV', nodecl> end -- Generate image: vertical gradient
-function Raylib.GenImageGradientH(width: cint, height: cint, left: Color, right: Color): Image <cimport'GenImageGradientH', nodecl> end -- Generate image: horizontal gradient
-function Raylib.GenImageGradientRadial(width: cint, height: cint, density: float32, inner: Color, outer: Color): Image <cimport'GenImageGradientRadial', nodecl> end -- Generate image: radial gradient
-function Raylib.GenImageChecked(width: cint, height: cint, checksX: cint, checksY: cint, col1: Color, col2: Color): Image <cimport'GenImageChecked', nodecl> end -- Generate image: checked
-function Raylib.GenImageWhiteNoise(width: cint, height: cint, factor: float32): Image <cimport'GenImageWhiteNoise', nodecl> end -- Generate image: white noise
-function Raylib.GenImagePerlinNoise(width: cint, height: cint, offsetX: cint, offsetY: cint, scale: float32): Image <cimport'GenImagePerlinNoise', nodecl> end -- Generate image: perlin noise
-function Raylib.GenImageCellular(width: cint, height: cint, tileSize: cint): Image <cimport'GenImageCellular', nodecl> end -- Generate image: cellular algorithm. Bigger tileSize means bigger cells
+function Raylib.GenImageColor(width: cint, height: cint, color: Color): Image <cimport'GenImageColor', cinclude'<raylib.h>', nodecl> end -- Generate image: plain color
+function Raylib.GenImageGradientV(width: cint, height: cint, top: Color, bottom: Color): Image <cimport'GenImageGradientV', cinclude'<raylib.h>', nodecl> end -- Generate image: vertical gradient
+function Raylib.GenImageGradientH(width: cint, height: cint, left: Color, right: Color): Image <cimport'GenImageGradientH', cinclude'<raylib.h>', nodecl> end -- Generate image: horizontal gradient
+function Raylib.GenImageGradientRadial(width: cint, height: cint, density: float32, inner: Color, outer: Color): Image <cimport'GenImageGradientRadial', cinclude'<raylib.h>', nodecl> end -- Generate image: radial gradient
+function Raylib.GenImageChecked(width: cint, height: cint, checksX: cint, checksY: cint, col1: Color, col2: Color): Image <cimport'GenImageChecked', cinclude'<raylib.h>', nodecl> end -- Generate image: checked
+function Raylib.GenImageWhiteNoise(width: cint, height: cint, factor: float32): Image <cimport'GenImageWhiteNoise', cinclude'<raylib.h>', nodecl> end -- Generate image: white noise
+function Raylib.GenImagePerlinNoise(width: cint, height: cint, offsetX: cint, offsetY: cint, scale: float32): Image <cimport'GenImagePerlinNoise', cinclude'<raylib.h>', nodecl> end -- Generate image: perlin noise
+function Raylib.GenImageCellular(width: cint, height: cint, tileSize: cint): Image <cimport'GenImageCellular', cinclude'<raylib.h>', nodecl> end -- Generate image: cellular algorithm. Bigger tileSize means bigger cells
 
 -- Image manipulation functions
-function Raylib.ImageCopy(image: Image): Image <cimport'ImageCopy', nodecl> end -- Create an image duplicate (useful for transformations)
-function Raylib.ImageFromImage(image: Image, rec: Rectangle): Image <cimport'ImageFromImage', nodecl> end -- Create an image from another image piece
-function Raylib.ImageText(text: cstring, fontSize: cint, color: Color): Image <cimport'ImageText', nodecl> end -- Create an image from text (default font)
-function Raylib.ImageTextEx(font: Font, text: cstring, fontSize: float32, spacing: float32, tint: Color): Image <cimport'ImageTextEx', nodecl> end -- Create an image from text (custom sprite font)
-function Raylib.ImageToPOT(image: Image*, fillColor: Color): void <cimport'ImageToPOT', nodecl> end -- Convert image to POT (power-of-two)
-function Raylib.ImageFormat(image: Image*, newFormat: cint): void <cimport'ImageFormat', nodecl> end -- Convert image data to desired format
-function Raylib.ImageAlphaMask(image: Image*, alphaMask: Image): void <cimport'ImageAlphaMask', nodecl> end -- Apply alpha mask to image
-function Raylib.ImageAlphaClear(image: Image*, color: Color, threshold: float32): void <cimport'ImageAlphaClear', nodecl> end -- Clear alpha channel to desired color
-function Raylib.ImageAlphaCrop(image: Image*, threshold: float32): void <cimport'ImageAlphaCrop', nodecl> end -- Crop image depending on alpha value
-function Raylib.ImageAlphaPremultiply(image: Image*): void <cimport'ImageAlphaPremultiply', nodecl> end -- Premultiply alpha channel
-function Raylib.ImageCrop(image: Image*, crop: Rectangle): void <cimport'ImageCrop', nodecl> end -- Crop an image to a defined rectangle
-function Raylib.ImageResize(image: Image*, newWidth: cint, newHeight: cint): void <cimport'ImageResize', nodecl> end -- Resize image (Bicubic scaling algorithm)
-function Raylib.ImageResizeNN(image: Image*, newWidth: cint, newHeight: cint): void <cimport'ImageResizeNN', nodecl> end -- Resize image (Nearest-Neighbor scaling algorithm)
-function Raylib.ImageResizeCanvas(image: Image*, newWidth: cint, newHeight: cint, offsetX: cint, offsetY: cint, color: Color): void <cimport'ImageResizeCanvas', nodecl> end -- Resize canvas and fill with color
-function Raylib.ImageMipmaps(image: Image*): void <cimport'ImageMipmaps', nodecl> end -- Generate all mipmap levels for a provided image
-function Raylib.ImageDither(image: Image*, rBpp: cint, gBpp: cint, bBpp: cint, aBpp: cint): void <cimport'ImageDither', nodecl> end -- Dither image data to 16bpp or lower (Floyd-Steinberg dithering)
-function Raylib.ImageFlipVertical(image: Image*): void <cimport'ImageFlipVertical', nodecl> end -- Flip image vertically
-function Raylib.ImageFlipHorizontal(image: Image*): void <cimport'ImageFlipHorizontal', nodecl> end -- Flip image horizontally
-function Raylib.ImageRotateCW(image: Image*): void <cimport'ImageRotateCW', nodecl> end -- Rotate image clockwise 90deg
-function Raylib.ImageRotateCCW(image: Image*): void <cimport'ImageRotateCCW', nodecl> end -- Rotate image counter-clockwise 90deg
-function Raylib.ImageColorTint(image: Image*, color: Color): void <cimport'ImageColorTint', nodecl> end -- Modify image color: tint
-function Raylib.ImageColorInvert(image: Image*): void <cimport'ImageColorInvert', nodecl> end -- Modify image color: invert
-function Raylib.ImageColorGrayscale(image: Image*): void <cimport'ImageColorGrayscale', nodecl> end -- Modify image color: grayscale
-function Raylib.ImageColorContrast(image: Image*, contrast: float32): void <cimport'ImageColorContrast', nodecl> end -- Modify image color: contrast (-100 to 100)
-function Raylib.ImageColorBrightness(image: Image*, brightness: cint): void <cimport'ImageColorBrightness', nodecl> end -- Modify image color: brightness (-255 to 255)
-function Raylib.ImageColorReplace(image: Image*, color: Color, replace: Color): void <cimport'ImageColorReplace', nodecl> end -- Modify image color: replace color
-function Raylib.ImageExtractPalette(image: Image, maxPaletteSize: cint, extractCount: cint*): Color[0]* <cimport'ImageExtractPalette', nodecl> end -- Extract color palette from image to maximum size (memory should be freed)
-function Raylib.GetImageAlphaBorder(image: Image, threshold: float32): Rectangle <cimport'GetImageAlphaBorder', nodecl> end -- Get image alpha border rectangle
+function Raylib.ImageCopy(image: Image): Image <cimport'ImageCopy', cinclude'<raylib.h>', nodecl> end -- Create an image duplicate (useful for transformations)
+function Image.Copy(image: Image): Image <cimport'ImageCopy', cinclude'<raylib.h>', nodecl> end -- Create an image duplicate (useful for transformations)
+
+function Raylib.ImageFromImage(image: Image, rec: Rectangle): Image <cimport'ImageFromImage', cinclude'<raylib.h>', nodecl> end -- Create an image from another image piece
+function Image.FromImage(image: Image, rec: Rectangle): Image <cimport'ImageFromImage', cinclude'<raylib.h>', nodecl> end -- Create an image from another image piece
+
+function Raylib.ImageText(text: cstring, fontSize: cint, color: Color): Image <cimport'ImageText', cinclude'<raylib.h>', nodecl> end -- Create an image from text (default font)
+function Image.Text(text: cstring, fontSize: cint, color: Color): Image <cimport'ImageText', cinclude'<raylib.h>', nodecl> end -- Create an image from text (default font)
+
+function Raylib.ImageTextEx(font: Font, text: cstring, fontSize: float32, spacing: float32, tint: Color): Image <cimport'ImageTextEx', cinclude'<raylib.h>', nodecl> end -- Create an image from text (custom sprite font)
+function Image.TextEx(font: Font, text: cstring, fontSize: float32, spacing: float32, tint: Color): Image <cimport'ImageTextEx', cinclude'<raylib.h>', nodecl> end -- Create an image from text (custom sprite font)
+
+function Raylib.ImageToPOT(image: *Image, fillColor: Color): void <cimport'ImageToPOT', cinclude'<raylib.h>', nodecl> end -- Convert image to POT (power-of-two)
+function Image.ToPOT(image: *Image, fillColor: Color): void <cimport'ImageToPOT', cinclude'<raylib.h>', nodecl> end -- Convert image to POT (power-of-two)
+
+function Raylib.ImageFormat(image: *Image, newFormat: cint): void <cimport'ImageFormat', cinclude'<raylib.h>', nodecl> end -- Convert image data to desired format
+function Image.Format(image: *Image, newFormat: cint): void <cimport'ImageFormat', cinclude'<raylib.h>', nodecl> end -- Convert image data to desired format
+
+function Raylib.ImageAlphaMask(image: *Image, alphaMask: Image): void <cimport'ImageAlphaMask', cinclude'<raylib.h>', nodecl> end -- Apply alpha mask to image
+function Image.AlphaMask(image: *Image, alphaMask: Image): void <cimport'ImageAlphaMask', cinclude'<raylib.h>', nodecl> end -- Apply alpha mask to image
+
+function Raylib.ImageAlphaClear(image: *Image, color: Color, threshold: float32): void <cimport'ImageAlphaClear', cinclude'<raylib.h>', nodecl> end -- Clear alpha channel to desired color
+function Image.AlphaClear(image: *Image, color: Color, threshold: float32): void <cimport'ImageAlphaClear', cinclude'<raylib.h>', nodecl> end -- Clear alpha channel to desired color
+
+function Raylib.ImageAlphaCrop(image: *Image, threshold: float32): void <cimport'ImageAlphaCrop', cinclude'<raylib.h>', nodecl> end -- Crop image depending on alpha value
+function Image.AlphaCrop(image: *Image, threshold: float32): void <cimport'ImageAlphaCrop', cinclude'<raylib.h>', nodecl> end -- Crop image depending on alpha value
+
+function Raylib.ImageAlphaPremultiply(image: *Image): void <cimport'ImageAlphaPremultiply', cinclude'<raylib.h>', nodecl> end -- Premultiply alpha channel
+function Image.AlphaPremultiply(image: *Image): void <cimport'ImageAlphaPremultiply', cinclude'<raylib.h>', nodecl> end -- Premultiply alpha channel
+
+function Raylib.ImageCrop(image: *Image, crop: Rectangle): void <cimport'ImageCrop', cinclude'<raylib.h>', nodecl> end -- Crop an image to a defined rectangle
+function Image.Crop(image: *Image, crop: Rectangle): void <cimport'ImageCrop', cinclude'<raylib.h>', nodecl> end -- Crop an image to a defined rectangle
+
+function Raylib.ImageResize(image: *Image, newWidth: cint, newHeight: cint): void <cimport'ImageResize', cinclude'<raylib.h>', nodecl> end -- Resize image (Bicubic scaling algorithm)
+function Image.Resize(image: *Image, newWidth: cint, newHeight: cint): void <cimport'ImageResize', cinclude'<raylib.h>', nodecl> end -- Resize image (Bicubic scaling algorithm)
+
+function Raylib.ImageResizeNN(image: *Image, newWidth: cint, newHeight: cint): void <cimport'ImageResizeNN', cinclude'<raylib.h>', nodecl> end -- Resize image (Nearest-Neighbor scaling algorithm)
+function Image.ResizeNN(image: *Image, newWidth: cint, newHeight: cint): void <cimport'ImageResizeNN', cinclude'<raylib.h>', nodecl> end -- Resize image (Nearest-Neighbor scaling algorithm)
+
+function Raylib.ImageResizeCanvas(image: *Image, newWidth: cint, newHeight: cint, offsetX: cint, offsetY: cint, color: Color): void <cimport'ImageResizeCanvas', cinclude'<raylib.h>', nodecl> end -- Resize canvas and fill with color
+function Image.ResizeCanvas(image: *Image, newWidth: cint, newHeight: cint, offsetX: cint, offsetY: cint, color: Color): void <cimport'ImageResizeCanvas', cinclude'<raylib.h>', nodecl> end -- Resize canvas and fill with color
+
+function Raylib.ImageMipmaps(image: *Image): void <cimport'ImageMipmaps', cinclude'<raylib.h>', nodecl> end -- Generate all mipmap levels for a provided image
+function Image.Mipmaps(image: *Image): void <cimport'ImageMipmaps', cinclude'<raylib.h>', nodecl> end -- Generate all mipmap levels for a provided image
+
+function Raylib.ImageDither(image: *Image, rBpp: cint, gBpp: cint, bBpp: cint, aBpp: cint): void <cimport'ImageDither', cinclude'<raylib.h>', nodecl> end -- Dither image data to 16bpp or lower (Floyd-Steinberg dithering)
+function Image.Dither(image: *Image, rBpp: cint, gBpp: cint, bBpp: cint, aBpp: cint): void <cimport'ImageDither', cinclude'<raylib.h>', nodecl> end -- Dither image data to 16bpp or lower (Floyd-Steinberg dithering)
+
+function Raylib.ImageFlipVertical(image: *Image): void <cimport'ImageFlipVertical', cinclude'<raylib.h>', nodecl> end -- Flip image vertically
+function Image.FlipVertical(image: *Image): void <cimport'ImageFlipVertical', cinclude'<raylib.h>', nodecl> end -- Flip image vertically
+
+function Raylib.ImageFlipHorizontal(image: *Image): void <cimport'ImageFlipHorizontal', cinclude'<raylib.h>', nodecl> end -- Flip image horizontally
+function Image.FlipHorizontal(image: *Image): void <cimport'ImageFlipHorizontal', cinclude'<raylib.h>', nodecl> end -- Flip image horizontally
+
+function Raylib.ImageRotateCW(image: *Image): void <cimport'ImageRotateCW', cinclude'<raylib.h>', nodecl> end -- Rotate image clockwise 90deg
+function Image.RotateCW(image: *Image): void <cimport'ImageRotateCW', cinclude'<raylib.h>', nodecl> end -- Rotate image clockwise 90deg
+
+function Raylib.ImageRotateCCW(image: *Image): void <cimport'ImageRotateCCW', cinclude'<raylib.h>', nodecl> end -- Rotate image counter-clockwise 90deg
+function Image.RotateCCW(image: *Image): void <cimport'ImageRotateCCW', cinclude'<raylib.h>', nodecl> end -- Rotate image counter-clockwise 90deg
+
+function Raylib.ImageColorTint(image: *Image, color: Color): void <cimport'ImageColorTint', cinclude'<raylib.h>', nodecl> end -- Modify image color: tint
+function Image.ColorTint(image: *Image, color: Color): void <cimport'ImageColorTint', cinclude'<raylib.h>', nodecl> end -- Modify image color: tint
+
+function Raylib.ImageColorInvert(image: *Image): void <cimport'ImageColorInvert', cinclude'<raylib.h>', nodecl> end -- Modify image color: invert
+function Image.ColorInvert(image: *Image): void <cimport'ImageColorInvert', cinclude'<raylib.h>', nodecl> end -- Modify image color: invert
+
+function Raylib.ImageColorGrayscale(image: *Image): void <cimport'ImageColorGrayscale', cinclude'<raylib.h>', nodecl> end -- Modify image color: grayscale
+function Image.ColorGrayscale(image: *Image): void <cimport'ImageColorGrayscale', cinclude'<raylib.h>', nodecl> end -- Modify image color: grayscale
+
+function Raylib.ImageColorContrast(image: *Image, contrast: float32): void <cimport'ImageColorContrast', cinclude'<raylib.h>', nodecl> end -- Modify image color: contrast (-100 to 100)
+function Image.ColorContrast(image: *Image, contrast: float32): void <cimport'ImageColorContrast', cinclude'<raylib.h>', nodecl> end -- Modify image color: contrast (-100 to 100)
+
+function Raylib.ImageColorBrightness(image: *Image, brightness: cint): void <cimport'ImageColorBrightness', cinclude'<raylib.h>', nodecl> end -- Modify image color: brightness (-255 to 255)
+function Image.ColorBrightness(image: *Image, brightness: cint): void <cimport'ImageColorBrightness', cinclude'<raylib.h>', nodecl> end -- Modify image color: brightness (-255 to 255)
+
+function Raylib.ImageColorReplace(image: *Image, color: Color, replace: Color): void <cimport'ImageColorReplace', cinclude'<raylib.h>', nodecl> end -- Modify image color: replace color
+function Image.ColorReplace(image: *Image, color: Color, replace: Color): void <cimport'ImageColorReplace', cinclude'<raylib.h>', nodecl> end -- Modify image color: replace color
+
+function Raylib.ImageExtractPalette(image: Image, maxPaletteSize: cint, extractCount: *cint): *[0]Color <cimport'ImageExtractPalette', cinclude'<raylib.h>', nodecl> end -- Extract color palette from image to maximum size (memory should be freed)
+function Image.ExtractPalette(image: Image, maxPaletteSize: cint, extractCount: *cint): *[0]Color <cimport'ImageExtractPalette', cinclude'<raylib.h>', nodecl> end -- Extract color palette from image to maximum size (memory should be freed)
+
+function Raylib.GetImageAlphaBorder(image: Image, threshold: float32): Rectangle <cimport'GetImageAlphaBorder', cinclude'<raylib.h>', nodecl> end -- Get image alpha border rectangle
 
 -- Image drawing functions
 -- NOTE: Image software-rendering functions (CPU)
-function Raylib.ImageClearBackground(dst: Image*, color: Color): void <cimport'ImageClearBackground', nodecl> end -- Clear image background with given color
-function Raylib.ImageDrawPixel(dst: Image*, posX: cint, posY: cint, color: Color): void <cimport'ImageDrawPixel', nodecl> end -- Draw pixel within an image
-function Raylib.ImageDrawPixelV(dst: Image*, position: Vector2, color: Color): void <cimport'ImageDrawPixelV', nodecl> end -- Draw pixel within an image (Vector version)
-function Raylib.ImageDrawLine(dst: Image*, startPosX: cint, startPosY: cint, endPosX: cint, endPosY: cint, color: Color): void <cimport'ImageDrawLine', nodecl> end -- Draw line within an image
-function Raylib.ImageDrawLineV(dst: Image*, start: Vector2, _end: Vector2, color: Color): void <cimport'ImageDrawLineV', nodecl> end -- Draw line within an image (Vector version)
-function Raylib.ImageDrawCircle(dst: Image*, centerX: cint, centerY: cint, radius: cint, color: Color): void <cimport'ImageDrawCircle', nodecl> end -- Draw circle within an image
-function Raylib.ImageDrawCircleV(dst: Image*, center: Vector2, radius: cint, color: Color): void <cimport'ImageDrawCircleV', nodecl> end -- Draw circle within an image (Vector version)
-function Raylib.ImageDrawRectangle(dst: Image*, posX: cint, posY: cint, width: cint, height: cint, color: Color): void <cimport'ImageDrawRectangle', nodecl> end -- Draw rectangle within an image
-function Raylib.ImageDrawRectangleV(dst: Image*, position: Vector2, size: Vector2, color: Color): void <cimport'ImageDrawRectangleV', nodecl> end -- Draw rectangle within an image (Vector version)
-function Raylib.ImageDrawRectangleRec(dst: Image*, rec: Rectangle, color: Color): void <cimport'ImageDrawRectangleRec', nodecl> end -- Draw rectangle within an image
-function Raylib.ImageDrawRectangleLines(dst: Image*, rec: Rectangle, thick: cint, color: Color): void <cimport'ImageDrawRectangleLines', nodecl> end -- Draw rectangle lines within an image
-function Raylib.ImageDraw(dst: Image*, src: Image, srcRec: Rectangle, dstRec: Rectangle, tint: Color): void <cimport'ImageDraw', nodecl> end -- Draw a source image within a destination image (tint applied to source)
-function Raylib.ImageDrawText(dst: Image*, position: Vector2, text: cstring, fontSize: cint, color: Color): void <cimport'ImageDrawText', nodecl> end -- Draw text (default font) within an image (destination)
-function Raylib.ImageDrawTextEx(dst: Image*, position: Vector2, font: Font, text: cstring, fontSize: float32, spacing: float32, color: Color): void <cimport'ImageDrawTextEx', nodecl> end -- Draw text (custom sprite font) within an image (destination)
+function Raylib.ImageClearBackground(dst: *Image, color: Color): void <cimport'ImageClearBackground', cinclude'<raylib.h>', nodecl> end -- Clear image background with given color
+function Image.ClearBackground(dst: *Image, color: Color): void <cimport'ImageClearBackground', cinclude'<raylib.h>', nodecl> end -- Clear image background with given color
+
+function Raylib.ImageDrawPixel(dst: *Image, posX: cint, posY: cint, color: Color): void <cimport'ImageDrawPixel', cinclude'<raylib.h>', nodecl> end -- Draw pixel within an image
+function Image.DrawPixel(dst: *Image, posX: cint, posY: cint, color: Color): void <cimport'ImageDrawPixel', cinclude'<raylib.h>', nodecl> end -- Draw pixel within an image
+
+function Raylib.ImageDrawPixelV(dst: *Image, position: Vector2, color: Color): void <cimport'ImageDrawPixelV', cinclude'<raylib.h>', nodecl> end -- Draw pixel within an image (Vector version)
+function Image.DrawPixelV(dst: *Image, position: Vector2, color: Color): void <cimport'ImageDrawPixelV', cinclude'<raylib.h>', nodecl> end -- Draw pixel within an image (Vector version)
+
+function Raylib.ImageDrawLine(dst: *Image, startPosX: cint, startPosY: cint, endPosX: cint, endPosY: cint, color: Color): void <cimport'ImageDrawLine', cinclude'<raylib.h>', nodecl> end -- Draw line within an image
+function Image.DrawLine(dst: *Image, startPosX: cint, startPosY: cint, endPosX: cint, endPosY: cint, color: Color): void <cimport'ImageDrawLine', cinclude'<raylib.h>', nodecl> end -- Draw line within an image
+
+function Raylib.ImageDrawLineV(dst: *Image, start: Vector2, _end: Vector2, color: Color): void <cimport'ImageDrawLineV', cinclude'<raylib.h>', nodecl> end -- Draw line within an image (Vector version)
+function Image.DrawLineV(dst: *Image, start: Vector2, _end: Vector2, color: Color): void <cimport'ImageDrawLineV', cinclude'<raylib.h>', nodecl> end -- Draw line within an image (Vector version)
+
+function Raylib.ImageDrawCircle(dst: *Image, centerX: cint, centerY: cint, radius: cint, color: Color): void <cimport'ImageDrawCircle', cinclude'<raylib.h>', nodecl> end -- Draw circle within an image
+function Image.DrawCircle(dst: *Image, centerX: cint, centerY: cint, radius: cint, color: Color): void <cimport'ImageDrawCircle', cinclude'<raylib.h>', nodecl> end -- Draw circle within an image
+
+function Raylib.ImageDrawCircleV(dst: *Image, center: Vector2, radius: cint, color: Color): void <cimport'ImageDrawCircleV', cinclude'<raylib.h>', nodecl> end -- Draw circle within an image (Vector version)
+function Image.DrawCircleV(dst: *Image, center: Vector2, radius: cint, color: Color): void <cimport'ImageDrawCircleV', cinclude'<raylib.h>', nodecl> end -- Draw circle within an image (Vector version)
+
+function Raylib.ImageDrawRectangle(dst: *Image, posX: cint, posY: cint, width: cint, height: cint, color: Color): void <cimport'ImageDrawRectangle', cinclude'<raylib.h>', nodecl> end -- Draw rectangle within an image
+function Image.DrawRectangle(dst: *Image, posX: cint, posY: cint, width: cint, height: cint, color: Color): void <cimport'ImageDrawRectangle', cinclude'<raylib.h>', nodecl> end -- Draw rectangle within an image
+
+function Raylib.ImageDrawRectangleV(dst: *Image, position: Vector2, size: Vector2, color: Color): void <cimport'ImageDrawRectangleV', cinclude'<raylib.h>', nodecl> end -- Draw rectangle within an image (Vector version)
+function Image.DrawRectangleV(dst: *Image, position: Vector2, size: Vector2, color: Color): void <cimport'ImageDrawRectangleV', cinclude'<raylib.h>', nodecl> end -- Draw rectangle within an image (Vector version)
+
+function Raylib.ImageDrawRectangleRec(dst: *Image, rec: Rectangle, color: Color): void <cimport'ImageDrawRectangleRec', cinclude'<raylib.h>', nodecl> end -- Draw rectangle within an image
+function Image.DrawRectangleRec(dst: *Image, rec: Rectangle, color: Color): void <cimport'ImageDrawRectangleRec', cinclude'<raylib.h>', nodecl> end -- Draw rectangle within an image
+
+function Raylib.ImageDrawRectangleLines(dst: *Image, rec: Rectangle, thick: cint, color: Color): void <cimport'ImageDrawRectangleLines', cinclude'<raylib.h>', nodecl> end -- Draw rectangle lines within an image
+function Image.DrawRectangleLines(dst: *Image, rec: Rectangle, thick: cint, color: Color): void <cimport'ImageDrawRectangleLines', cinclude'<raylib.h>', nodecl> end -- Draw rectangle lines within an image
+
+function Raylib.ImageDraw(dst: *Image, src: Image, srcRec: Rectangle, dstRec: Rectangle, tint: Color): void <cimport'ImageDraw', cinclude'<raylib.h>', nodecl> end -- Draw a source image within a destination image (tint applied to source)
+function Image.Draw(dst: *Image, src: Image, srcRec: Rectangle, dstRec: Rectangle, tint: Color): void <cimport'ImageDraw', cinclude'<raylib.h>', nodecl> end -- Draw a source image within a destination image (tint applied to source)
+
+function Raylib.ImageDrawText(dst: *Image, position: Vector2, text: cstring, fontSize: cint, color: Color): void <cimport'ImageDrawText', cinclude'<raylib.h>', nodecl> end -- Draw text (default font) within an image (destination)
+function Image.DrawText(dst: *Image, position: Vector2, text: cstring, fontSize: cint, color: Color): void <cimport'ImageDrawText', cinclude'<raylib.h>', nodecl> end -- Draw text (default font) within an image (destination)
+
+function Raylib.ImageDrawTextEx(dst: *Image, position: Vector2, font: Font, text: cstring, fontSize: float32, spacing: float32, color: Color): void <cimport'ImageDrawTextEx', cinclude'<raylib.h>', nodecl> end -- Draw text (custom sprite font) within an image (destination)
+function Image.DrawTextEx(dst: *Image, position: Vector2, font: Font, text: cstring, fontSize: float32, spacing: float32, color: Color): void <cimport'ImageDrawTextEx', cinclude'<raylib.h>', nodecl> end -- Draw text (custom sprite font) within an image (destination)
+
 
 -- Texture loading functions
 -- NOTE: These functions require GPU access
-function Raylib.LoadTexture(fileName: cstring): Texture2D <cimport'LoadTexture', nodecl> end -- Load texture from file into GPU memory (VRAM)
-function Raylib.LoadTextureFromImage(image: Image): Texture2D <cimport'LoadTextureFromImage', nodecl> end -- Load texture from image data
-function Raylib.LoadTextureCubemap(image: Image, layoutType: cint): TextureCubemap <cimport'LoadTextureCubemap', nodecl> end -- Load cubemap from image, multiple image cubemap layouts supported
-function Raylib.LoadRenderTexture(width: cint, height: cint): RenderTexture2D <cimport'LoadRenderTexture', nodecl> end -- Load texture for rendering (framebuffer)
-function Raylib.UnloadTexture(texture: Texture2D): void <cimport'UnloadTexture', nodecl> end -- Unload texture from GPU memory (VRAM)
-function Raylib.UnloadRenderTexture(target: RenderTexture2D): void <cimport'UnloadRenderTexture', nodecl> end -- Unload render texture from GPU memory (VRAM)
-function Raylib.UpdateTexture(texture: Texture2D, pixels: pointer): void <cimport'UpdateTexture', nodecl> end -- Update GPU texture with new data
-function Raylib.GetTextureData(texture: Texture2D): Image <cimport'GetTextureData', nodecl> end -- Get pixel data from GPU texture and return an Image
-function Raylib.GetScreenData(): Image <cimport'GetScreenData', nodecl> end -- Get pixel data from screen buffer and return an Image (screenshot)
+function Raylib.LoadTexture(fileName: cstring): Texture2D <cimport'LoadTexture', cinclude'<raylib.h>', nodecl> end -- Load texture from file into GPU memory (VRAM)
+function Raylib.LoadTextureFromImage(image: Image): Texture2D <cimport'LoadTextureFromImage', cinclude'<raylib.h>', nodecl> end -- Load texture from image data
+function Raylib.LoadTextureCubemap(image: Image, layoutType: cint): TextureCubemap <cimport'LoadTextureCubemap', cinclude'<raylib.h>', nodecl> end -- Load cubemap from image, multiple image cubemap layouts supported
+function Raylib.LoadRenderTexture(width: cint, height: cint): RenderTexture2D <cimport'LoadRenderTexture', cinclude'<raylib.h>', nodecl> end -- Load texture for rendering (framebuffer)
+function Raylib.UnloadTexture(texture: Texture2D): void <cimport'UnloadTexture', cinclude'<raylib.h>', nodecl> end -- Unload texture from GPU memory (VRAM)
+function Raylib.UnloadRenderTexture(target: RenderTexture2D): void <cimport'UnloadRenderTexture', cinclude'<raylib.h>', nodecl> end -- Unload render texture from GPU memory (VRAM)
+function Raylib.UpdateTexture(texture: Texture2D, pixels: pointer): void <cimport'UpdateTexture', cinclude'<raylib.h>', nodecl> end -- Update GPU texture with new data
+function Raylib.GetTextureData(texture: Texture2D): Image <cimport'GetTextureData', cinclude'<raylib.h>', nodecl> end -- Get pixel data from GPU texture and return an Image
+function Raylib.GetScreenData(): Image <cimport'GetScreenData', cinclude'<raylib.h>', nodecl> end -- Get pixel data from screen buffer and return an Image (screenshot)
 
 -- Texture configuration functions
-function Raylib.GenTextureMipmaps(texture: Texture2D*): void <cimport'GenTextureMipmaps', nodecl> end -- Generate GPU mipmaps for a texture
-function Raylib.SetTextureFilter(texture: Texture2D, filterMode: cint): void <cimport'SetTextureFilter', nodecl> end -- Set texture scaling filter mode
-function Raylib.SetTextureWrap(texture: Texture2D, wrapMode: cint): void <cimport'SetTextureWrap', nodecl> end -- Set texture wrapping mode
+function Raylib.GenTextureMipmaps(texture: *Texture2D): void <cimport'GenTextureMipmaps', cinclude'<raylib.h>', nodecl> end -- Generate GPU mipmaps for a texture
+function Texture2D.GenTextureMipmaps(texture: *Texture2D): void <cimport'GenTextureMipmaps', cinclude'<raylib.h>', nodecl> end -- Generate GPU mipmaps for a texture
+
+function Raylib.SetTextureFilter(texture: Texture2D, filterMode: cint): void <cimport'SetTextureFilter', cinclude'<raylib.h>', nodecl> end -- Set texture scaling filter mode
+function Raylib.SetTextureWrap(texture: Texture2D, wrapMode: cint): void <cimport'SetTextureWrap', cinclude'<raylib.h>', nodecl> end -- Set texture wrapping mode
 
 -- Texture drawing functions
-function Raylib.DrawTexture(texture: Texture2D, posX: cint, posY: cint, tint: Color): void <cimport'DrawTexture', nodecl> end -- Draw a Texture2D
-function Raylib.DrawTextureV(texture: Texture2D, position: Vector2, tint: Color): void <cimport'DrawTextureV', nodecl> end -- Draw a Texture2D with position defined as Vector2
-function Raylib.DrawTextureEx(texture: Texture2D, position: Vector2, rotation: float32, scale: float32, tint: Color): void <cimport'DrawTextureEx', nodecl> end -- Draw a Texture2D with extended parameters
-function Raylib.DrawTextureRec(texture: Texture2D, sourceRec: Rectangle, position: Vector2, tint: Color): void <cimport'DrawTextureRec', nodecl> end -- Draw a part of a texture defined by a rectangle
-function Raylib.DrawTextureQuad(texture: Texture2D, tiling: Vector2, offset: Vector2, quad: Rectangle, tint: Color): void <cimport'DrawTextureQuad', nodecl> end -- Draw texture quad with tiling and offset parameters
-function Raylib.DrawTexturePro(texture: Texture2D, sourceRec: Rectangle, destRec: Rectangle, origin: Vector2, rotation: float32, tint: Color): void <cimport'DrawTexturePro', nodecl> end -- Draw a part of a texture defined by a rectangle with 'pro' parameters
-function Raylib.DrawTextureNPatch(texture: Texture2D, nPatchInfo: NPatchInfo, destRec: Rectangle, origin: Vector2, rotation: float32, tint: Color): void <cimport'DrawTextureNPatch', nodecl> end -- Draws a texture (or part of it) that stretches or shrinks nicely
+function Raylib.DrawTexture(texture: Texture2D, posX: cint, posY: cint, tint: Color): void <cimport'DrawTexture', cinclude'<raylib.h>', nodecl> end -- Draw a Texture2D
+function Raylib.DrawTextureV(texture: Texture2D, position: Vector2, tint: Color): void <cimport'DrawTextureV', cinclude'<raylib.h>', nodecl> end -- Draw a Texture2D with position defined as Vector2
+function Raylib.DrawTextureEx(texture: Texture2D, position: Vector2, rotation: float32, scale: float32, tint: Color): void <cimport'DrawTextureEx', cinclude'<raylib.h>', nodecl> end -- Draw a Texture2D with extended parameters
+function Raylib.DrawTextureRec(texture: Texture2D, sourceRec: Rectangle, position: Vector2, tint: Color): void <cimport'DrawTextureRec', cinclude'<raylib.h>', nodecl> end -- Draw a part of a texture defined by a rectangle
+function Raylib.DrawTextureQuad(texture: Texture2D, tiling: Vector2, offset: Vector2, quad: Rectangle, tint: Color): void <cimport'DrawTextureQuad', cinclude'<raylib.h>', nodecl> end -- Draw texture quad with tiling and offset parameters
+function Raylib.DrawTexturePro(texture: Texture2D, sourceRec: Rectangle, destRec: Rectangle, origin: Vector2, rotation: float32, tint: Color): void <cimport'DrawTexturePro', cinclude'<raylib.h>', nodecl> end -- Draw a part of a texture defined by a rectangle with 'pro' parameters
+function Raylib.DrawTextureNPatch(texture: Texture2D, nPatchInfo: NPatchInfo, destRec: Rectangle, origin: Vector2, rotation: float32, tint: Color): void <cimport'DrawTextureNPatch', cinclude'<raylib.h>', nodecl> end -- Draws a texture (or part of it) that stretches or shrinks nicely
 
 -- Image/Texture misc functions
-function Raylib.GetPixelDataSize(width: cint, height: cint, format: cint): cint <cimport'GetPixelDataSize', nodecl> end -- Get pixel data size in bytes (image or texture)
+function Raylib.GetPixelDataSize(width: cint, height: cint, format: cint): cint <cimport'GetPixelDataSize', cinclude'<raylib.h>', nodecl> end -- Get pixel data size in bytes (image or texture)
 
 -- ------------------------------------------------------------------------------------
 -- Font Loading and Text Drawing Functions (Module: text)
 -- ------------------------------------------------------------------------------------
 
 -- Font loading/unloading functions
-function Raylib.GetFontDefault(): Font <cimport'GetFontDefault', nodecl> end -- Get the default Font
-function Raylib.LoadFont(fileName: cstring): Font <cimport'LoadFont', nodecl> end -- Load font from file into GPU memory (VRAM)
-function Raylib.LoadFontEx(fileName: cstring, fontSize: cint, fontChars: cint[0]*, charsCount: cint): Font <cimport'LoadFontEx', nodecl> end -- Load font from file with extended parameters
-function Raylib.LoadFontFromImage(image: Image, key: Color, firstChar: cint): Font <cimport'LoadFontFromImage', nodecl> end -- Load font from Image (XNA style)
-function Raylib.LoadFontData(fileName: cstring, fontSize: cint, fontChars: cint[0]*, charsCount: cint, type: cint): CharInfo[0]* <cimport'LoadFontData', nodecl> end -- Load font data for further use
-function Raylib.GenImageFontAtlas(chars: CharInfo[0]*, recs: Rectangle[0]*[0]*, charsCount: cint, fontSize: cint, padding: cint, packMethod: cint): Image <cimport'GenImageFontAtlas', nodecl> end -- Generate image font atlas using chars info
-function Raylib.UnloadFont(font: Font): void <cimport'UnloadFont', nodecl> end -- Unload Font from GPU memory (VRAM)
+function Raylib.GetFontDefault(): Font <cimport'GetFontDefault', cinclude'<raylib.h>', nodecl> end -- Get the default Font
+function Raylib.LoadFont(fileName: cstring): Font <cimport'LoadFont', cinclude'<raylib.h>', nodecl> end -- Load font from file into GPU memory (VRAM)
+function Raylib.LoadFontEx(fileName: cstring, fontSize: cint, fontChars: *[0]cint, charsCount: cint): Font <cimport'LoadFontEx', cinclude'<raylib.h>', nodecl> end -- Load font from file with extended parameters
+function Raylib.LoadFontFromImage(image: Image, key: Color, firstChar: cint): Font <cimport'LoadFontFromImage', cinclude'<raylib.h>', nodecl> end -- Load font from Image (XNA style)
+function Raylib.LoadFontData(fileName: cstring, fontSize: cint, fontChars: *[0]cint, charsCount: cint, type: cint): *[0]CharInfo <cimport'LoadFontData', cinclude'<raylib.h>', nodecl> end -- Load font data for further use
+function Raylib.GenImageFontAtlas(chars: *[0]CharInfo, recs: **[0]Rectangle, charsCount: cint, fontSize: cint, padding: cint, packMethod: cint): Image <cimport'GenImageFontAtlas', cinclude'<raylib.h>', nodecl> end -- Generate image font atlas using chars info
+function Raylib.UnloadFont(font: Font): void <cimport'UnloadFont', cinclude'<raylib.h>', nodecl> end -- Unload Font from GPU memory (VRAM)
 
 -- Text drawing functions
-function Raylib.DrawFPS(posX: cint, posY: cint): void <cimport'DrawFPS', nodecl> end -- Shows current FPS
-function Raylib.DrawText(text: cstring, posX: cint, posY: cint, fontSize: cint, color: Color): void <cimport'DrawText', nodecl> end -- Draw text (using default font)
-function Raylib.DrawTextEx(font: Font, text: cstring, position: Vector2, fontSize: float32, spacing: float32, tint: Color): void <cimport'DrawTextEx', nodecl> end -- Draw text using font and additional parameters
-function Raylib.DrawTextRec(font: Font, text: cstring, rec: Rectangle, fontSize: float32, spacing: float32, wordWrap: boolean, tint: Color): void <cimport'DrawTextRec', nodecl> end -- Draw text using font inside rectangle limits
-function Raylib.DrawTextRecEx(font: Font, text: cstring, rec: Rectangle, fontSize: float32, spacing: float32, wordWrap: boolean, tint: Color, selectStart: cint, selectLength: cint, selectTint: Color, selectBackTint: Color): void <cimport'DrawTextRecEx', nodecl> end -- Draw text using font inside rectangle limits with support for text selection
-function Raylib.DrawTextCodepoint(font: Font, codepoint: cint, position: Vector2, scale: float32, tint: Color): void <cimport'DrawTextCodepoint', nodecl> end -- Draw one character (codepoint)
+function Raylib.DrawFPS(posX: cint, posY: cint): void <cimport'DrawFPS', cinclude'<raylib.h>', nodecl> end -- Shows current FPS
+function Raylib.DrawText(text: cstring, posX: cint, posY: cint, fontSize: cint, color: Color): void <cimport'DrawText', cinclude'<raylib.h>', nodecl> end -- Draw text (using default font)
+function Raylib.DrawTextEx(font: Font, text: cstring, position: Vector2, fontSize: float32, spacing: float32, tint: Color): void <cimport'DrawTextEx', cinclude'<raylib.h>', nodecl> end -- Draw text using font and additional parameters
+function Raylib.DrawTextRec(font: Font, text: cstring, rec: Rectangle, fontSize: float32, spacing: float32, wordWrap: boolean, tint: Color): void <cimport'DrawTextRec', cinclude'<raylib.h>', nodecl> end -- Draw text using font inside rectangle limits
+function Raylib.DrawTextRecEx(font: Font, text: cstring, rec: Rectangle, fontSize: float32, spacing: float32, wordWrap: boolean, tint: Color, selectStart: cint, selectLength: cint, selectTint: Color, selectBackTint: Color): void <cimport'DrawTextRecEx', cinclude'<raylib.h>', nodecl> end -- Draw text using font inside rectangle limits with support for text selection
+function Raylib.DrawTextCodepoint(font: Font, codepoint: cint, position: Vector2, scale: float32, tint: Color): void <cimport'DrawTextCodepoint', cinclude'<raylib.h>', nodecl> end -- Draw one character (codepoint)
 
 -- Text misc. functions
-function Raylib.MeasureText(text: cstring, fontSize: cint): cint <cimport'MeasureText', nodecl> end -- Measure string width for default font
-function Raylib.MeasureTextEx(font: Font, text: cstring, fontSize: float32, spacing: float32): Vector2 <cimport'MeasureTextEx', nodecl> end -- Measure string size for Font
-function Raylib.GetGlyphIndex(font: Font, codepoint: cint): cint <cimport'GetGlyphIndex', nodecl> end -- Get index position for a unicode character on font
+function Raylib.MeasureText(text: cstring, fontSize: cint): cint <cimport'MeasureText', cinclude'<raylib.h>', nodecl> end -- Measure string width for default font
+function Raylib.MeasureTextEx(font: Font, text: cstring, fontSize: float32, spacing: float32): Vector2 <cimport'MeasureTextEx', cinclude'<raylib.h>', nodecl> end -- Measure string size for Font
+function Raylib.GetGlyphIndex(font: Font, codepoint: cint): cint <cimport'GetGlyphIndex', cinclude'<raylib.h>', nodecl> end -- Get index position for a unicode character on font
 
 -- Text strings management functions (no utf8 strings, only byte chars)
 -- NOTE: Some strings allocate memory internally for returned strings, just be careful!
-function Raylib.TextCopy(dst: cstring, src: cstring): cint <cimport'TextCopy', nodecl> end -- Copy one string to another, returns bytes copied
-function Raylib.TextIsEqual(text1: cstring, text2: cstring): boolean <cimport'TextIsEqual', nodecl> end -- Check if two text string are equal
-function Raylib.TextLength(text: cstring): cuint <cimport'TextLength', nodecl> end -- Get text length, checks for '\0' ending
-function Raylib.TextFormat(text: cstring, ...): cstring <cimport'TextFormat', nodecl> end -- Text formatting with variables (sprintf style)
-function Raylib.TextSubtext(text: cstring, position: cint, length: cint): cstring <cimport'TextSubtext', nodecl> end -- Get a piece of a text string
-function Raylib.TextReplace(text: cstring, replace: cstring, by: cstring): cstring <cimport'TextReplace', nodecl> end -- Replace text string (memory must be freed!)
-function Raylib.TextInsert(text: cstring, insert: cstring, position: cint): cstring <cimport'TextInsert', nodecl> end -- Insert text in a position (memory must be freed!)
-function Raylib.TextJoin(textList: cstring[0]*, count: cint, delimiter: cstring): cstring <cimport'TextJoin', nodecl> end -- Join text strings with delimiter
-function Raylib.TextSplit(text: cstring, delimiter: cchar, count: cint*): cstring[0]* <cimport'TextSplit', nodecl> end -- Split text into multiple strings
-function Raylib.TextAppend(text: cstring, append: cstring, position: cint*): void <cimport'TextAppend', nodecl> end -- Append text at specific position and move cursor!
-function Raylib.TextFindIndex(text: cstring, find: cstring): cint <cimport'TextFindIndex', nodecl> end -- Find first text occurrence within a string
-function Raylib.TextToUpper(text: cstring): cstring <cimport'TextToUpper', nodecl> end -- Get upper case version of provided string
-function Raylib.TextToLower(text: cstring): cstring <cimport'TextToLower', nodecl> end -- Get lower case version of provided string
-function Raylib.TextToPascal(text: cstring): cstring <cimport'TextToPascal', nodecl> end -- Get Pascal case notation version of provided string
-function Raylib.TextToInteger(text: cstring): cint <cimport'TextToInteger', nodecl> end -- Get integer value from text (negative values not supported)
-function Raylib.TextToUtf8(codepoints: cint[0]*, length: cint): cstring <cimport'TextToUtf8', nodecl> end -- Encode text codepoint into utf8 text (memory must be freed!)
+function Raylib.TextCopy(dst: cstring, src: cstring): cint <cimport'TextCopy', cinclude'<raylib.h>', nodecl> end -- Copy one string to another, returns bytes copied
+function Raylib.TextIsEqual(text1: cstring, text2: cstring): boolean <cimport'TextIsEqual', cinclude'<raylib.h>', nodecl> end -- Check if two text string are equal
+function Raylib.TextLength(text: cstring): cuint <cimport'TextLength', cinclude'<raylib.h>', nodecl> end -- Get text length, checks for '\0' ending
+function Raylib.TextFormat(text: cstring, ...: cvarargs): cstring <cimport'TextFormat', cinclude'<raylib.h>', nodecl> end -- Text formatting with variables (sprintf style)
+function Raylib.TextSubtext(text: cstring, position: cint, length: cint): cstring <cimport'TextSubtext', cinclude'<raylib.h>', nodecl> end -- Get a piece of a text string
+function Raylib.TextReplace(text: cstring, replace: cstring, by: cstring): cstring <cimport'TextReplace', cinclude'<raylib.h>', nodecl> end -- Replace text string (memory must be freed!)
+function Raylib.TextInsert(text: cstring, insert: cstring, position: cint): cstring <cimport'TextInsert', cinclude'<raylib.h>', nodecl> end -- Insert text in a position (memory must be freed!)
+function Raylib.TextJoin(textList: *[0]cstring, count: cint, delimiter: cstring): cstring <cimport'TextJoin', cinclude'<raylib.h>', nodecl> end -- Join text strings with delimiter
+function Raylib.TextSplit(text: cstring, delimiter: cchar, count: *cint): *[0]cstring <cimport'TextSplit', cinclude'<raylib.h>', nodecl> end -- Split text into multiple strings
+function Raylib.TextAppend(text: cstring, append: cstring, position: *cint): void <cimport'TextAppend', cinclude'<raylib.h>', nodecl> end -- Append text at specific position and move cursor!
+function Raylib.TextFindIndex(text: cstring, find: cstring): cint <cimport'TextFindIndex', cinclude'<raylib.h>', nodecl> end -- Find first text occurrence within a string
+function Raylib.TextToUpper(text: cstring): cstring <cimport'TextToUpper', cinclude'<raylib.h>', nodecl> end -- Get upper case version of provided string
+function Raylib.TextToLower(text: cstring): cstring <cimport'TextToLower', cinclude'<raylib.h>', nodecl> end -- Get lower case version of provided string
+function Raylib.TextToPascal(text: cstring): cstring <cimport'TextToPascal', cinclude'<raylib.h>', nodecl> end -- Get Pascal case notation version of provided string
+function Raylib.TextToInteger(text: cstring): cint <cimport'TextToInteger', cinclude'<raylib.h>', nodecl> end -- Get integer value from text (negative values not supported)
+function Raylib.TextToUtf8(codepoints: *[0]cint, length: cint): cstring <cimport'TextToUtf8', cinclude'<raylib.h>', nodecl> end -- Encode text codepoint into utf8 text (memory must be freed!)
 
 -- UTF8 text strings management functions
-function Raylib.GetCodepoints(text: cstring, count: cint*): cint[0]* <cimport'GetCodepoints', nodecl> end -- Get all codepoints in a string, codepoints count returned by parameters
-function Raylib.GetCodepointsCount(text: cstring): cint <cimport'GetCodepointsCount', nodecl> end -- Get total number of characters (codepoints) in a UTF8 encoded string
-function Raylib.GetNextCodepoint(text: cstring, bytesProcessed: cint*): cint <cimport'GetNextCodepoint', nodecl> end -- Returns next codepoint in a UTF8 encoded string; 0x3f('?') is returned on failure
-function Raylib.CodepointToUtf8(codepoint: cint, byteLength: cint*): cstring <cimport'CodepointToUtf8', nodecl> end -- Encode codepoint into utf8 text (char array length returned as parameter)
+function Raylib.GetCodepoints(text: cstring, count: *cint): *[0]cint <cimport'GetCodepoints', cinclude'<raylib.h>', nodecl> end -- Get all codepoints in a string, codepoints count returned by parameters
+function Raylib.GetCodepointsCount(text: cstring): cint <cimport'GetCodepointsCount', cinclude'<raylib.h>', nodecl> end -- Get total number of characters (codepoints) in a UTF8 encoded string
+function Raylib.GetNextCodepoint(text: cstring, bytesProcessed: *cint): cint <cimport'GetNextCodepoint', cinclude'<raylib.h>', nodecl> end -- Returns next codepoint in a UTF8 encoded string; 0x3f('?') is returned on failure
+function Raylib.CodepointToUtf8(codepoint: cint, byteLength: *cint): cstring <cimport'CodepointToUtf8', cinclude'<raylib.h>', nodecl> end -- Encode codepoint into utf8 text (char array length returned as parameter)
 
 -- ------------------------------------------------------------------------------------
 -- Basic 3d Shapes Drawing Functions (Module: models)
 -- ------------------------------------------------------------------------------------
 
 -- Basic geometric 3D shapes drawing functions
-function Raylib.DrawLine3D(startPos: Vector3, endPos: Vector3, color: Color): void <cimport'DrawLine3D', nodecl> end -- Draw a line in 3D world space
-function Raylib.DrawPoint3D(position: Vector3, color: Color): void <cimport'DrawPoint3D', nodecl> end -- Draw a point in 3D space, actually a small line
-function Raylib.DrawCircle3D(center: Vector3, radius: float32, rotationAxis: Vector3, rotationAngle: float32, color: Color): void <cimport'DrawCircle3D', nodecl> end -- Draw a circle in 3D world space
-function Raylib.DrawCube(position: Vector3, width: float32, height: float32, length: float32, color: Color): void <cimport'DrawCube', nodecl> end -- Draw cube
-function Raylib.DrawCubeV(position: Vector3, size: Vector3, color: Color): void <cimport'DrawCubeV', nodecl> end -- Draw cube (Vector version)
-function Raylib.DrawCubeWires(position: Vector3, width: float32, height: float32, length: float32, color: Color): void <cimport'DrawCubeWires', nodecl> end -- Draw cube wires
-function Raylib.DrawCubeWiresV(position: Vector3, size: Vector3, color: Color): void <cimport'DrawCubeWiresV', nodecl> end -- Draw cube wires (Vector version)
-function Raylib.DrawCubeTexture(texture: Texture2D, position: Vector3, width: float32, height: float32, length: float32, color: Color): void <cimport'DrawCubeTexture', nodecl> end -- Draw cube textured
-function Raylib.DrawSphere(centerPos: Vector3, radius: float32, color: Color): void <cimport'DrawSphere', nodecl> end -- Draw sphere
-function Raylib.DrawSphereEx(centerPos: Vector3, radius: float32, rings: cint, slices: cint, color: Color): void <cimport'DrawSphereEx', nodecl> end -- Draw sphere with extended parameters
-function Raylib.DrawSphereWires(centerPos: Vector3, radius: float32, rings: cint, slices: cint, color: Color): void <cimport'DrawSphereWires', nodecl> end -- Draw sphere wires
-function Raylib.DrawCylinder(position: Vector3, radiusTop: float32, radiusBottom: float32, height: float32, slices: cint, color: Color): void <cimport'DrawCylinder', nodecl> end -- Draw a cylinder/cone
-function Raylib.DrawCylinderWires(position: Vector3, radiusTop: float32, radiusBottom: float32, height: float32, slices: cint, color: Color): void <cimport'DrawCylinderWires', nodecl> end -- Draw a cylinder/cone wires
-function Raylib.DrawPlane(centerPos: Vector3, size: Vector2, color: Color): void <cimport'DrawPlane', nodecl> end -- Draw a plane XZ
-function Raylib.DrawRay(ray: Ray, color: Color): void <cimport'DrawRay', nodecl> end -- Draw a ray line
-function Raylib.DrawGrid(slices: cint, spacing: float32): void <cimport'DrawGrid', nodecl> end -- Draw a grid (centered at (0, 0, 0))
-function Raylib.DrawGizmo(position: Vector3): void <cimport'DrawGizmo', nodecl> end -- Draw simple gizmo
+function Raylib.DrawLine3D(startPos: Vector3, endPos: Vector3, color: Color): void <cimport'DrawLine3D', cinclude'<raylib.h>', nodecl> end -- Draw a line in 3D world space
+function Raylib.DrawPoint3D(position: Vector3, color: Color): void <cimport'DrawPoint3D', cinclude'<raylib.h>', nodecl> end -- Draw a point in 3D space, actually a small line
+function Raylib.DrawCircle3D(center: Vector3, radius: float32, rotationAxis: Vector3, rotationAngle: float32, color: Color): void <cimport'DrawCircle3D', cinclude'<raylib.h>', nodecl> end -- Draw a circle in 3D world space
+function Raylib.DrawCube(position: Vector3, width: float32, height: float32, length: float32, color: Color): void <cimport'DrawCube', cinclude'<raylib.h>', nodecl> end -- Draw cube
+function Raylib.DrawCubeV(position: Vector3, size: Vector3, color: Color): void <cimport'DrawCubeV', cinclude'<raylib.h>', nodecl> end -- Draw cube (Vector version)
+function Raylib.DrawCubeWires(position: Vector3, width: float32, height: float32, length: float32, color: Color): void <cimport'DrawCubeWires', cinclude'<raylib.h>', nodecl> end -- Draw cube wires
+function Raylib.DrawCubeWiresV(position: Vector3, size: Vector3, color: Color): void <cimport'DrawCubeWiresV', cinclude'<raylib.h>', nodecl> end -- Draw cube wires (Vector version)
+function Raylib.DrawCubeTexture(texture: Texture2D, position: Vector3, width: float32, height: float32, length: float32, color: Color): void <cimport'DrawCubeTexture', cinclude'<raylib.h>', nodecl> end -- Draw cube textured
+function Raylib.DrawSphere(centerPos: Vector3, radius: float32, color: Color): void <cimport'DrawSphere', cinclude'<raylib.h>', nodecl> end -- Draw sphere
+function Raylib.DrawSphereEx(centerPos: Vector3, radius: float32, rings: cint, slices: cint, color: Color): void <cimport'DrawSphereEx', cinclude'<raylib.h>', nodecl> end -- Draw sphere with extended parameters
+function Raylib.DrawSphereWires(centerPos: Vector3, radius: float32, rings: cint, slices: cint, color: Color): void <cimport'DrawSphereWires', cinclude'<raylib.h>', nodecl> end -- Draw sphere wires
+function Raylib.DrawCylinder(position: Vector3, radiusTop: float32, radiusBottom: float32, height: float32, slices: cint, color: Color): void <cimport'DrawCylinder', cinclude'<raylib.h>', nodecl> end -- Draw a cylinder/cone
+function Raylib.DrawCylinderWires(position: Vector3, radiusTop: float32, radiusBottom: float32, height: float32, slices: cint, color: Color): void <cimport'DrawCylinderWires', cinclude'<raylib.h>', nodecl> end -- Draw a cylinder/cone wires
+function Raylib.DrawPlane(centerPos: Vector3, size: Vector2, color: Color): void <cimport'DrawPlane', cinclude'<raylib.h>', nodecl> end -- Draw a plane XZ
+function Raylib.DrawRay(ray: Ray, color: Color): void <cimport'DrawRay', cinclude'<raylib.h>', nodecl> end -- Draw a ray line
+function Raylib.DrawGrid(slices: cint, spacing: float32): void <cimport'DrawGrid', cinclude'<raylib.h>', nodecl> end -- Draw a grid (centered at (0, 0, 0))
+function Raylib.DrawGizmo(position: Vector3): void <cimport'DrawGizmo', cinclude'<raylib.h>', nodecl> end -- Draw simple gizmo
 -- DrawTorus(), DrawTeapot() could be useful?
 
 -- ------------------------------------------------------------------------------------
@@ -1169,64 +1249,74 @@ function Raylib.DrawGizmo(position: Vector3): void <cimport'DrawGizmo', nodecl> 
 -- ------------------------------------------------------------------------------------
 
 -- Model loading/unloading functions
-function Raylib.LoadModel(fileName: cstring): Model <cimport'LoadModel', nodecl> end -- Load model from files (meshes and materials)
-function Raylib.LoadModelFromMesh(mesh: Mesh): Model <cimport'LoadModelFromMesh', nodecl> end -- Load model from generated mesh (default material)
-function Raylib.UnloadModel(model: Model): void <cimport'UnloadModel', nodecl> end -- Unload model from memory (RAM and/or VRAM)
+function Raylib.LoadModel(fileName: cstring): Model <cimport'LoadModel', cinclude'<raylib.h>', nodecl> end -- Load model from files (meshes and materials)
+function Raylib.LoadModelFromMesh(mesh: Mesh): Model <cimport'LoadModelFromMesh', cinclude'<raylib.h>', nodecl> end -- Load model from generated mesh (default material)
+function Raylib.UnloadModel(model: Model): void <cimport'UnloadModel', cinclude'<raylib.h>', nodecl> end -- Unload model from memory (RAM and/or VRAM)
 
 -- Mesh loading/unloading functions
-function Raylib.LoadMeshes(fileName: cstring, meshCount: cint*): Mesh[0]* <cimport'LoadMeshes', nodecl> end -- Load meshes from model file
-function Raylib.ExportMesh(mesh: Mesh, fileName: cstring): void <cimport'ExportMesh', nodecl> end -- Export mesh data to file
-function Raylib.UnloadMesh(mesh: Mesh): void <cimport'UnloadMesh', nodecl> end -- Unload mesh from memory (RAM and/or VRAM)
+function Raylib.LoadMeshes(fileName: cstring, meshCount: *cint): *[0]Mesh <cimport'LoadMeshes', cinclude'<raylib.h>', nodecl> end -- Load meshes from model file
+function Raylib.ExportMesh(mesh: Mesh, fileName: cstring): void <cimport'ExportMesh', cinclude'<raylib.h>', nodecl> end -- Export mesh data to file
+function Raylib.UnloadMesh(mesh: Mesh): void <cimport'UnloadMesh', cinclude'<raylib.h>', nodecl> end -- Unload mesh from memory (RAM and/or VRAM)
 
 -- Material loading/unloading functions
-function Raylib.LoadMaterials(fileName: cstring, materialCount: cint*): Material[0]* <cimport'LoadMaterials', nodecl> end -- Load materials from model file
-function Raylib.LoadMaterialDefault(): Material <cimport'LoadMaterialDefault', nodecl> end -- Load default material (Supports: DIFFUSE, SPECULAR, NORMAL maps)
-function Raylib.UnloadMaterial(material: Material): void <cimport'UnloadMaterial', nodecl> end -- Unload material from GPU memory (VRAM)
-function Raylib.SetMaterialTexture(material: Material*, mapType: cint, texture: Texture2D): void <cimport'SetMaterialTexture', nodecl> end -- Set texture for a material map type (MAP_DIFFUSE, MAP_SPECULAR...)
-function Raylib.SetModelMeshMaterial(model: Model*, meshId: cint, materialId: cint): void <cimport'SetModelMeshMaterial', nodecl> end -- Set material for a mesh
+function Raylib.LoadMaterials(fileName: cstring, materialCount: *cint): *[0]Material <cimport'LoadMaterials', cinclude'<raylib.h>', nodecl> end -- Load materials from model file
+function Raylib.LoadMaterialDefault(): Material <cimport'LoadMaterialDefault', cinclude'<raylib.h>', nodecl> end -- Load default material (Supports: DIFFUSE, SPECULAR, NORMAL maps)
+function Raylib.UnloadMaterial(material: Material): void <cimport'UnloadMaterial', cinclude'<raylib.h>', nodecl> end -- Unload material from GPU memory (VRAM)
+function Raylib.SetMaterialTexture(material: *Material, mapType: cint, texture: Texture2D): void <cimport'SetMaterialTexture', cinclude'<raylib.h>', nodecl> end -- Set texture for a material map type (MAP_DIFFUSE, MAP_SPECULAR...)
+function Texture2D.SetMaterialTexture(material: *Material, mapType: cint, texture: Texture2D): void <cimport'SetMaterialTexture', cinclude'<raylib.h>', nodecl> end -- Set texture for a material map type (MAP_DIFFUSE, MAP_SPECULAR...)
+
+function Raylib.SetModelMeshMaterial(model: *Model, meshId: cint, materialId: cint): void <cimport'SetModelMeshMaterial', cinclude'<raylib.h>', nodecl> end -- Set material for a mesh
+function Texture2D.SetModelMeshMaterial(model: *Model, meshId: cint, materialId: cint): void <cimport'SetModelMeshMaterial', cinclude'<raylib.h>', nodecl> end -- Set material for a mesh
+
 
 -- Model animations loading/unloading functions
-function Raylib.LoadModelAnimations(fileName: cstring, animsCount: cint*): ModelAnimation[0]* <cimport'LoadModelAnimations', nodecl> end -- Load model animations from file
-function Raylib.UpdateModelAnimation(model: Model, anim: ModelAnimation, frame: cint): void <cimport'UpdateModelAnimation', nodecl> end -- Update model animation pose
-function Raylib.UnloadModelAnimation(anim: ModelAnimation): void <cimport'UnloadModelAnimation', nodecl> end -- Unload animation data
-function Raylib.IsModelAnimationValid(model: Model, anim: ModelAnimation): boolean <cimport'IsModelAnimationValid', nodecl> end -- Check model animation skeleton match
+function Raylib.LoadModelAnimations(fileName: cstring, animsCount: *cint): *[0]ModelAnimation <cimport'LoadModelAnimations', cinclude'<raylib.h>', nodecl> end -- Load model animations from file
+function Raylib.UpdateModelAnimation(model: Model, anim: ModelAnimation, frame: cint): void <cimport'UpdateModelAnimation', cinclude'<raylib.h>', nodecl> end -- Update model animation pose
+function Raylib.UnloadModelAnimation(anim: ModelAnimation): void <cimport'UnloadModelAnimation', cinclude'<raylib.h>', nodecl> end -- Unload animation data
+function Raylib.IsModelAnimationValid(model: Model, anim: ModelAnimation): boolean <cimport'IsModelAnimationValid', cinclude'<raylib.h>', nodecl> end -- Check model animation skeleton match
 
 -- Mesh generation functions
-function Raylib.GenMeshPoly(sides: cint, radius: float32): Mesh <cimport'GenMeshPoly', nodecl> end -- Generate polygonal mesh
-function Raylib.GenMeshPlane(width: float32, length: float32, resX: cint, resZ: cint): Mesh <cimport'GenMeshPlane', nodecl> end -- Generate plane mesh (with subdivisions)
-function Raylib.GenMeshCube(width: float32, height: float32, length: float32): Mesh <cimport'GenMeshCube', nodecl> end -- Generate cuboid mesh
-function Raylib.GenMeshSphere(radius: float32, rings: cint, slices: cint): Mesh <cimport'GenMeshSphere', nodecl> end -- Generate sphere mesh (standard sphere)
-function Raylib.GenMeshHemiSphere(radius: float32, rings: cint, slices: cint): Mesh <cimport'GenMeshHemiSphere', nodecl> end -- Generate half-sphere mesh (no bottom cap)
-function Raylib.GenMeshCylinder(radius: float32, height: float32, slices: cint): Mesh <cimport'GenMeshCylinder', nodecl> end -- Generate cylinder mesh
-function Raylib.GenMeshTorus(radius: float32, size: float32, radSeg: cint, sides: cint): Mesh <cimport'GenMeshTorus', nodecl> end -- Generate torus mesh
-function Raylib.GenMeshKnot(radius: float32, size: float32, radSeg: cint, sides: cint): Mesh <cimport'GenMeshKnot', nodecl> end -- Generate trefoil knot mesh
-function Raylib.GenMeshHeightmap(heightmap: Image, size: Vector3): Mesh <cimport'GenMeshHeightmap', nodecl> end -- Generate heightmap mesh from image data
-function Raylib.GenMeshCubicmap(cubicmap: Image, cubeSize: Vector3): Mesh <cimport'GenMeshCubicmap', nodecl> end -- Generate cubes-based map mesh from image data
+function Raylib.GenMeshPoly(sides: cint, radius: float32): Mesh <cimport'GenMeshPoly', cinclude'<raylib.h>', nodecl> end -- Generate polygonal mesh
+function Raylib.GenMeshPlane(width: float32, length: float32, resX: cint, resZ: cint): Mesh <cimport'GenMeshPlane', cinclude'<raylib.h>', nodecl> end -- Generate plane mesh (with subdivisions)
+function Raylib.GenMeshCube(width: float32, height: float32, length: float32): Mesh <cimport'GenMeshCube', cinclude'<raylib.h>', nodecl> end -- Generate cuboid mesh
+function Raylib.GenMeshSphere(radius: float32, rings: cint, slices: cint): Mesh <cimport'GenMeshSphere', cinclude'<raylib.h>', nodecl> end -- Generate sphere mesh (standard sphere)
+function Raylib.GenMeshHemiSphere(radius: float32, rings: cint, slices: cint): Mesh <cimport'GenMeshHemiSphere', cinclude'<raylib.h>', nodecl> end -- Generate half-sphere mesh (no bottom cap)
+function Raylib.GenMeshCylinder(radius: float32, height: float32, slices: cint): Mesh <cimport'GenMeshCylinder', cinclude'<raylib.h>', nodecl> end -- Generate cylinder mesh
+function Raylib.GenMeshTorus(radius: float32, size: float32, radSeg: cint, sides: cint): Mesh <cimport'GenMeshTorus', cinclude'<raylib.h>', nodecl> end -- Generate torus mesh
+function Raylib.GenMeshKnot(radius: float32, size: float32, radSeg: cint, sides: cint): Mesh <cimport'GenMeshKnot', cinclude'<raylib.h>', nodecl> end -- Generate trefoil knot mesh
+function Raylib.GenMeshHeightmap(heightmap: Image, size: Vector3): Mesh <cimport'GenMeshHeightmap', cinclude'<raylib.h>', nodecl> end -- Generate heightmap mesh from image data
+function Raylib.GenMeshCubicmap(cubicmap: Image, cubeSize: Vector3): Mesh <cimport'GenMeshCubicmap', cinclude'<raylib.h>', nodecl> end -- Generate cubes-based map mesh from image data
 
 -- Mesh manipulation functions
-function Raylib.MeshBoundingBox(mesh: Mesh): BoundingBox <cimport'MeshBoundingBox', nodecl> end -- Compute mesh bounding box limits
-function Raylib.MeshTangents(mesh: Mesh*): void <cimport'MeshTangents', nodecl> end -- Compute mesh tangents
-function Raylib.MeshBinormals(mesh: Mesh*): void <cimport'MeshBinormals', nodecl> end -- Compute mesh binormals
+function Raylib.MeshBoundingBox(mesh: Mesh): BoundingBox <cimport'MeshBoundingBox', cinclude'<raylib.h>', nodecl> end -- Compute mesh bounding box limits
+function Mesh.BoundingBox(mesh: Mesh): BoundingBox <cimport'MeshBoundingBox', cinclude'<raylib.h>', nodecl> end -- Compute mesh bounding box limits
+
+function Raylib.MeshTangents(mesh: *Mesh): void <cimport'MeshTangents', cinclude'<raylib.h>', nodecl> end -- Compute mesh tangents
+function Mesh.Tangents(mesh: *Mesh): void <cimport'MeshTangents', cinclude'<raylib.h>', nodecl> end -- Compute mesh tangents
+
+function Raylib.MeshBinormals(mesh: *Mesh): void <cimport'MeshBinormals', cinclude'<raylib.h>', nodecl> end -- Compute mesh binormals
+function Mesh.Binormals(mesh: *Mesh): void <cimport'MeshBinormals', cinclude'<raylib.h>', nodecl> end -- Compute mesh binormals
+
 
 -- Model drawing functions
-function Raylib.DrawModel(model: Model, position: Vector3, scale: float32, tint: Color): void <cimport'DrawModel', nodecl> end -- Draw a model (with texture if set)
-function Raylib.DrawModelEx(model: Model, position: Vector3, rotationAxis: Vector3, rotationAngle: float32, scale: Vector3, tint: Color): void <cimport'DrawModelEx', nodecl> end -- Draw a model with extended parameters
-function Raylib.DrawModelWires(model: Model, position: Vector3, scale: float32, tint: Color): void <cimport'DrawModelWires', nodecl> end -- Draw a model wires (with texture if set)
-function Raylib.DrawModelWiresEx(model: Model, position: Vector3, rotationAxis: Vector3, rotationAngle: float32, scale: Vector3, tint: Color): void <cimport'DrawModelWiresEx', nodecl> end -- Draw a model wires (with texture if set) with extended parameters
-function Raylib.DrawBoundingBox(box: BoundingBox, color: Color): void <cimport'DrawBoundingBox', nodecl> end -- Draw bounding box (wires)
-function Raylib.DrawBillboard(camera: Camera, texture: Texture2D, center: Vector3, size: float32, tint: Color): void <cimport'DrawBillboard', nodecl> end -- Draw a billboard texture
-function Raylib.DrawBillboardRec(camera: Camera, texture: Texture2D, sourceRec: Rectangle, center: Vector3, size: float32, tint: Color): void <cimport'DrawBillboardRec', nodecl> end -- Draw a billboard texture defined by sourceRec
+function Raylib.DrawModel(model: Model, position: Vector3, scale: float32, tint: Color): void <cimport'DrawModel', cinclude'<raylib.h>', nodecl> end -- Draw a model (with texture if set)
+function Raylib.DrawModelEx(model: Model, position: Vector3, rotationAxis: Vector3, rotationAngle: float32, scale: Vector3, tint: Color): void <cimport'DrawModelEx', cinclude'<raylib.h>', nodecl> end -- Draw a model with extended parameters
+function Raylib.DrawModelWires(model: Model, position: Vector3, scale: float32, tint: Color): void <cimport'DrawModelWires', cinclude'<raylib.h>', nodecl> end -- Draw a model wires (with texture if set)
+function Raylib.DrawModelWiresEx(model: Model, position: Vector3, rotationAxis: Vector3, rotationAngle: float32, scale: Vector3, tint: Color): void <cimport'DrawModelWiresEx', cinclude'<raylib.h>', nodecl> end -- Draw a model wires (with texture if set) with extended parameters
+function Raylib.DrawBoundingBox(box: BoundingBox, color: Color): void <cimport'DrawBoundingBox', cinclude'<raylib.h>', nodecl> end -- Draw bounding box (wires)
+function Raylib.DrawBillboard(camera: Camera, texture: Texture2D, center: Vector3, size: float32, tint: Color): void <cimport'DrawBillboard', cinclude'<raylib.h>', nodecl> end -- Draw a billboard texture
+function Raylib.DrawBillboardRec(camera: Camera, texture: Texture2D, sourceRec: Rectangle, center: Vector3, size: float32, tint: Color): void <cimport'DrawBillboardRec', cinclude'<raylib.h>', nodecl> end -- Draw a billboard texture defined by sourceRec
 
 -- Collision detection functions
-function Raylib.CheckCollisionSpheres(centerA: Vector3, radiusA: float32, centerB: Vector3, radiusB: float32): boolean <cimport'CheckCollisionSpheres', nodecl> end -- Detect collision between two spheres
-function Raylib.CheckCollisionBoxes(box1: BoundingBox, box2: BoundingBox): boolean <cimport'CheckCollisionBoxes', nodecl> end -- Detect collision between two bounding boxes
-function Raylib.CheckCollisionBoxSphere(box: BoundingBox, center: Vector3, radius: float32): boolean <cimport'CheckCollisionBoxSphere', nodecl> end -- Detect collision between box and sphere
-function Raylib.CheckCollisionRaySphere(ray: Ray, center: Vector3, radius: float32): boolean <cimport'CheckCollisionRaySphere', nodecl> end -- Detect collision between ray and sphere
-function Raylib.CheckCollisionRaySphereEx(ray: Ray, center: Vector3, radius: float32, collisionPoint: Vector3*): boolean <cimport'CheckCollisionRaySphereEx', nodecl> end -- Detect collision between ray and sphere, returns collision point
-function Raylib.CheckCollisionRayBox(ray: Ray, box: BoundingBox): boolean <cimport'CheckCollisionRayBox', nodecl> end -- Detect collision between ray and box
-function Raylib.GetCollisionRayModel(ray: Ray, model: Model): RayHitInfo <cimport'GetCollisionRayModel', nodecl> end -- Get collision info between ray and model
-function Raylib.GetCollisionRayTriangle(ray: Ray, p1: Vector3, p2: Vector3, p3: Vector3): RayHitInfo <cimport'GetCollisionRayTriangle', nodecl> end -- Get collision info between ray and triangle
-function Raylib.GetCollisionRayGround(ray: Ray, groundHeight: float32): RayHitInfo <cimport'GetCollisionRayGround', nodecl> end -- Get collision info between ray and ground plane (Y-normal plane)
+function Raylib.CheckCollisionSpheres(centerA: Vector3, radiusA: float32, centerB: Vector3, radiusB: float32): boolean <cimport'CheckCollisionSpheres', cinclude'<raylib.h>', nodecl> end -- Detect collision between two spheres
+function Raylib.CheckCollisionBoxes(box1: BoundingBox, box2: BoundingBox): boolean <cimport'CheckCollisionBoxes', cinclude'<raylib.h>', nodecl> end -- Detect collision between two bounding boxes
+function Raylib.CheckCollisionBoxSphere(box: BoundingBox, center: Vector3, radius: float32): boolean <cimport'CheckCollisionBoxSphere', cinclude'<raylib.h>', nodecl> end -- Detect collision between box and sphere
+function Raylib.CheckCollisionRaySphere(ray: Ray, center: Vector3, radius: float32): boolean <cimport'CheckCollisionRaySphere', cinclude'<raylib.h>', nodecl> end -- Detect collision between ray and sphere
+function Raylib.CheckCollisionRaySphereEx(ray: Ray, center: Vector3, radius: float32, collisionPoint: *Vector3): boolean <cimport'CheckCollisionRaySphereEx', cinclude'<raylib.h>', nodecl> end -- Detect collision between ray and sphere, returns collision point
+function Raylib.CheckCollisionRayBox(ray: Ray, box: BoundingBox): boolean <cimport'CheckCollisionRayBox', cinclude'<raylib.h>', nodecl> end -- Detect collision between ray and box
+function Raylib.GetCollisionRayModel(ray: Ray, model: Model): RayHitInfo <cimport'GetCollisionRayModel', cinclude'<raylib.h>', nodecl> end -- Get collision info between ray and model
+function Raylib.GetCollisionRayTriangle(ray: Ray, p1: Vector3, p2: Vector3, p3: Vector3): RayHitInfo <cimport'GetCollisionRayTriangle', cinclude'<raylib.h>', nodecl> end -- Get collision info between ray and triangle
+function Raylib.GetCollisionRayGround(ray: Ray, groundHeight: float32): RayHitInfo <cimport'GetCollisionRayGround', cinclude'<raylib.h>', nodecl> end -- Get collision info between ray and ground plane (Y-normal plane)
 
 -- ------------------------------------------------------------------------------------
 -- Shaders System Functions (Module: rlgl)
@@ -1234,159 +1324,167 @@ function Raylib.GetCollisionRayGround(ray: Ray, groundHeight: float32): RayHitIn
 -- ------------------------------------------------------------------------------------
 
 -- Shader loading/unloading functions
-function Raylib.LoadShader(vsFileName: cstring, fsFileName: cstring): Shader <cimport'LoadShader', nodecl> end -- Load shader from files and bind default locations
-function Raylib.LoadShaderCode(vsCode: cstring, fsCode: cstring): Shader <cimport'LoadShaderCode', nodecl> end -- Load shader from code strings and bind default locations
-function Raylib.UnloadShader(shader: Shader): void <cimport'UnloadShader', nodecl> end -- Unload shader from GPU memory (VRAM)
+function Raylib.LoadShader(vsFileName: cstring, fsFileName: cstring): Shader <cimport'LoadShader', cinclude'<raylib.h>', nodecl> end -- Load shader from files and bind default locations
+function Raylib.LoadShaderCode(vsCode: cstring, fsCode: cstring): Shader <cimport'LoadShaderCode', cinclude'<raylib.h>', nodecl> end -- Load shader from code strings and bind default locations
+function Raylib.UnloadShader(shader: Shader): void <cimport'UnloadShader', cinclude'<raylib.h>', nodecl> end -- Unload shader from GPU memory (VRAM)
 
-function Raylib.GetShaderDefault(): Shader <cimport'GetShaderDefault', nodecl> end -- Get default shader
-function Raylib.GetTextureDefault(): Texture2D <cimport'GetTextureDefault', nodecl> end -- Get default texture
-function Raylib.GetShapesTexture(): Texture2D <cimport'GetShapesTexture', nodecl> end -- Get texture to draw shapes
-function Raylib.GetShapesTextureRec(): Rectangle <cimport'GetShapesTextureRec', nodecl> end -- Get texture rectangle to draw shapes
-function Raylib.SetShapesTexture(texture: Texture2D, source: Rectangle): void <cimport'SetShapesTexture', nodecl> end -- Define default texture used to draw shapes
+function Raylib.GetShaderDefault(): Shader <cimport'GetShaderDefault', cinclude'<raylib.h>', nodecl> end -- Get default shader
+function Raylib.GetTextureDefault(): Texture2D <cimport'GetTextureDefault', cinclude'<raylib.h>', nodecl> end -- Get default texture
+function Raylib.GetShapesTexture(): Texture2D <cimport'GetShapesTexture', cinclude'<raylib.h>', nodecl> end -- Get texture to draw shapes
+function Raylib.GetShapesTextureRec(): Rectangle <cimport'GetShapesTextureRec', cinclude'<raylib.h>', nodecl> end -- Get texture rectangle to draw shapes
+function Raylib.SetShapesTexture(texture: Texture2D, source: Rectangle): void <cimport'SetShapesTexture', cinclude'<raylib.h>', nodecl> end -- Define default texture used to draw shapes
 
 -- Shader configuration functions
-function Raylib.GetShaderLocation(shader: Shader, uniformName: cstring): cint <cimport'GetShaderLocation', nodecl> end -- Get shader uniform location
-function Raylib.SetShaderValue(shader: Shader, uniformLoc: cint, value: pointer, uniformType: cint): void <cimport'SetShaderValue', nodecl> end -- Set shader uniform value
-function Raylib.SetShaderValueV(shader: Shader, uniformLoc: cint, value: pointer, uniformType: cint, count: cint): void <cimport'SetShaderValueV', nodecl> end -- Set shader uniform value vector
-function Raylib.SetShaderValueMatrix(shader: Shader, uniformLoc: cint, mat: Matrix): void <cimport'SetShaderValueMatrix', nodecl> end -- Set shader uniform value (matrix 4x4)
-function Raylib.SetShaderValueTexture(shader: Shader, uniformLoc: cint, texture: Texture2D): void <cimport'SetShaderValueTexture', nodecl> end -- Set shader uniform value for texture
-function Raylib.SetMatrixProjection(proj: Matrix): void <cimport'SetMatrixProjection', nodecl> end -- Set a custom projection matrix (replaces internal projection matrix)
-function Raylib.SetMatrixModelview(view: Matrix): void <cimport'SetMatrixModelview', nodecl> end -- Set a custom modelview matrix (replaces internal modelview matrix)
-function Raylib.GetMatrixModelview(): Matrix <cimport'GetMatrixModelview', nodecl> end -- Get internal modelview matrix
-function Raylib.GetMatrixProjection(): Matrix <cimport'GetMatrixProjection', nodecl> end -- Get internal projection matrix
+function Raylib.GetShaderLocation(shader: Shader, uniformName: cstring): cint <cimport'GetShaderLocation', cinclude'<raylib.h>', nodecl> end -- Get shader uniform location
+function Raylib.SetShaderValue(shader: Shader, uniformLoc: cint, value: pointer, uniformType: cint): void <cimport'SetShaderValue', cinclude'<raylib.h>', nodecl> end -- Set shader uniform value
+function Raylib.SetShaderValueV(shader: Shader, uniformLoc: cint, value: pointer, uniformType: cint, count: cint): void <cimport'SetShaderValueV', cinclude'<raylib.h>', nodecl> end -- Set shader uniform value vector
+function Raylib.SetShaderValueMatrix(shader: Shader, uniformLoc: cint, mat: Matrix): void <cimport'SetShaderValueMatrix', cinclude'<raylib.h>', nodecl> end -- Set shader uniform value (matrix 4x4)
+function Raylib.SetShaderValueTexture(shader: Shader, uniformLoc: cint, texture: Texture2D): void <cimport'SetShaderValueTexture', cinclude'<raylib.h>', nodecl> end -- Set shader uniform value for texture
+function Raylib.SetMatrixProjection(proj: Matrix): void <cimport'SetMatrixProjection', cinclude'<raylib.h>', nodecl> end -- Set a custom projection matrix (replaces internal projection matrix)
+function Raylib.SetMatrixModelview(view: Matrix): void <cimport'SetMatrixModelview', cinclude'<raylib.h>', nodecl> end -- Set a custom modelview matrix (replaces internal modelview matrix)
+function Raylib.GetMatrixModelview(): Matrix <cimport'GetMatrixModelview', cinclude'<raylib.h>', nodecl> end -- Get internal modelview matrix
+function Raylib.GetMatrixProjection(): Matrix <cimport'GetMatrixProjection', cinclude'<raylib.h>', nodecl> end -- Get internal projection matrix
 
 -- Texture maps generation (PBR)
 -- NOTE: Required shaders should be provided
-function Raylib.GenTextureCubemap(shader: Shader, map: Texture2D, size: cint): Texture2D <cimport'GenTextureCubemap', nodecl> end -- Generate cubemap texture from 2D texture
-function Raylib.GenTextureIrradiance(shader: Shader, cubemap: Texture2D, size: cint): Texture2D <cimport'GenTextureIrradiance', nodecl> end -- Generate irradiance texture using cubemap data
-function Raylib.GenTexturePrefilter(shader: Shader, cubemap: Texture2D, size: cint): Texture2D <cimport'GenTexturePrefilter', nodecl> end -- Generate prefilter texture using cubemap data
-function Raylib.GenTextureBRDF(shader: Shader, size: cint): Texture2D <cimport'GenTextureBRDF', nodecl> end -- Generate BRDF texture
+function Raylib.GenTextureCubemap(shader: Shader, map: Texture2D, size: cint): Texture2D <cimport'GenTextureCubemap', cinclude'<raylib.h>', nodecl> end -- Generate cubemap texture from 2D texture
+function Raylib.GenTextureIrradiance(shader: Shader, cubemap: Texture2D, size: cint): Texture2D <cimport'GenTextureIrradiance', cinclude'<raylib.h>', nodecl> end -- Generate irradiance texture using cubemap data
+function Raylib.GenTexturePrefilter(shader: Shader, cubemap: Texture2D, size: cint): Texture2D <cimport'GenTexturePrefilter', cinclude'<raylib.h>', nodecl> end -- Generate prefilter texture using cubemap data
+function Raylib.GenTextureBRDF(shader: Shader, size: cint): Texture2D <cimport'GenTextureBRDF', cinclude'<raylib.h>', nodecl> end -- Generate BRDF texture
 
 -- Shading begin/end functions
-function Raylib.BeginShaderMode(shader: Shader): void <cimport'BeginShaderMode', nodecl> end -- Begin custom shader drawing
-function Raylib.EndShaderMode(): void <cimport'EndShaderMode', nodecl> end -- End custom shader drawing (use default shader)
-function Raylib.BeginBlendMode(mode: cint): void <cimport'BeginBlendMode', nodecl> end -- Begin blending mode (alpha, additive, multiplied)
-function Raylib.EndBlendMode(): void <cimport'EndBlendMode', nodecl> end -- End blending mode (reset to default: alpha blending)
+function Raylib.BeginShaderMode(shader: Shader): void <cimport'BeginShaderMode', cinclude'<raylib.h>', nodecl> end -- Begin custom shader drawing
+function Raylib.EndShaderMode(): void <cimport'EndShaderMode', cinclude'<raylib.h>', nodecl> end -- End custom shader drawing (use default shader)
+function Raylib.BeginBlendMode(mode: cint): void <cimport'BeginBlendMode', cinclude'<raylib.h>', nodecl> end -- Begin blending mode (alpha, additive, multiplied)
+function Raylib.EndBlendMode(): void <cimport'EndBlendMode', cinclude'<raylib.h>', nodecl> end -- End blending mode (reset to default: alpha blending)
 
 -- VR control functions
-function Raylib.InitVrSimulator(): void <cimport'InitVrSimulator', nodecl> end -- Init VR simulator for selected device parameters
-function Raylib.CloseVrSimulator(): void <cimport'CloseVrSimulator', nodecl> end -- Close VR simulator for current device
-function Raylib.UpdateVrTracking(camera: Camera*): void <cimport'UpdateVrTracking', nodecl> end -- Update VR tracking (position and orientation) and camera
-function Raylib.SetVrConfiguration(info: VrDeviceInfo, distortion: Shader): void <cimport'SetVrConfiguration', nodecl> end -- Set stereo rendering configuration parameters
-function Raylib.IsVrSimulatorReady(): boolean <cimport'IsVrSimulatorReady', nodecl> end -- Detect if VR simulator is ready
-function Raylib.ToggleVrMode(): void <cimport'ToggleVrMode', nodecl> end -- Enable/Disable VR experience
-function Raylib.BeginVrDrawing(): void <cimport'BeginVrDrawing', nodecl> end -- Begin VR simulator stereo rendering
-function Raylib.EndVrDrawing(): void <cimport'EndVrDrawing', nodecl> end -- End VR simulator stereo rendering
+function Raylib.InitVrSimulator(): void <cimport'InitVrSimulator', cinclude'<raylib.h>', nodecl> end -- Init VR simulator for selected device parameters
+function Raylib.CloseVrSimulator(): void <cimport'CloseVrSimulator', cinclude'<raylib.h>', nodecl> end -- Close VR simulator for current device
+function Raylib.UpdateVrTracking(camera: *Camera): void <cimport'UpdateVrTracking', cinclude'<raylib.h>', nodecl> end -- Update VR tracking (position and orientation) and camera
+function Camera.UpdateVrTracking(camera: *Camera): void <cimport'UpdateVrTracking', cinclude'<raylib.h>', nodecl> end -- Update VR tracking (position and orientation) and camera
+
+function Raylib.SetVrConfiguration(info: VrDeviceInfo, distortion: Shader): void <cimport'SetVrConfiguration', cinclude'<raylib.h>', nodecl> end -- Set stereo rendering configuration parameters
+function Raylib.IsVrSimulatorReady(): boolean <cimport'IsVrSimulatorReady', cinclude'<raylib.h>', nodecl> end -- Detect if VR simulator is ready
+function Raylib.ToggleVrMode(): void <cimport'ToggleVrMode', cinclude'<raylib.h>', nodecl> end -- Enable/Disable VR experience
+function Raylib.BeginVrDrawing(): void <cimport'BeginVrDrawing', cinclude'<raylib.h>', nodecl> end -- Begin VR simulator stereo rendering
+function Raylib.EndVrDrawing(): void <cimport'EndVrDrawing', cinclude'<raylib.h>', nodecl> end -- End VR simulator stereo rendering
 
 -- ------------------------------------------------------------------------------------
 -- Audio Loading and Playing Functions (Module: audio)
 -- ------------------------------------------------------------------------------------
 
 -- Audio device management functions
-function Raylib.InitAudioDevice(): void <cimport'InitAudioDevice', nodecl> end -- Initialize audio device and context
-function Raylib.CloseAudioDevice(): void <cimport'CloseAudioDevice', nodecl> end -- Close the audio device and context
-function Raylib.IsAudioDeviceReady(): boolean <cimport'IsAudioDeviceReady', nodecl> end -- Check if audio device has been initialized successfully
-function Raylib.SetMasterVolume(volume: float32): void <cimport'SetMasterVolume', nodecl> end -- Set master volume (listener)
+function Raylib.InitAudioDevice(): void <cimport'InitAudioDevice', cinclude'<raylib.h>', nodecl> end -- Initialize audio device and context
+function Raylib.CloseAudioDevice(): void <cimport'CloseAudioDevice', cinclude'<raylib.h>', nodecl> end -- Close the audio device and context
+function Raylib.IsAudioDeviceReady(): boolean <cimport'IsAudioDeviceReady', cinclude'<raylib.h>', nodecl> end -- Check if audio device has been initialized successfully
+function Raylib.SetMasterVolume(volume: float32): void <cimport'SetMasterVolume', cinclude'<raylib.h>', nodecl> end -- Set master volume (listener)
 
 -- Wave/Sound loading/unloading functions
-function Raylib.LoadWave(fileName: cstring): Wave <cimport'LoadWave', nodecl> end -- Load wave data from file
-function Raylib.LoadSound(fileName: cstring): Sound <cimport'LoadSound', nodecl> end -- Load sound from file
-function Raylib.LoadSoundFromWave(wave: Wave): Sound <cimport'LoadSoundFromWave', nodecl> end -- Load sound from wave data
-function Raylib.UpdateSound(sound: Sound, data: pointer, samplesCount: cint): void <cimport'UpdateSound', nodecl> end -- Update sound buffer with new data
-function Raylib.UnloadWave(wave: Wave): void <cimport'UnloadWave', nodecl> end -- Unload wave data
-function Raylib.UnloadSound(sound: Sound): void <cimport'UnloadSound', nodecl> end -- Unload sound
-function Raylib.ExportWave(wave: Wave, fileName: cstring): void <cimport'ExportWave', nodecl> end -- Export wave data to file
-function Raylib.ExportWaveAsCode(wave: Wave, fileName: cstring): void <cimport'ExportWaveAsCode', nodecl> end -- Export wave sample data to code (.h)
+function Raylib.LoadWave(fileName: cstring): Wave <cimport'LoadWave', cinclude'<raylib.h>', nodecl> end -- Load wave data from file
+function Raylib.LoadSound(fileName: cstring): Sound <cimport'LoadSound', cinclude'<raylib.h>', nodecl> end -- Load sound from file
+function Raylib.LoadSoundFromWave(wave: Wave): Sound <cimport'LoadSoundFromWave', cinclude'<raylib.h>', nodecl> end -- Load sound from wave data
+function Raylib.UpdateSound(sound: Sound, data: pointer, samplesCount: cint): void <cimport'UpdateSound', cinclude'<raylib.h>', nodecl> end -- Update sound buffer with new data
+function Raylib.UnloadWave(wave: Wave): void <cimport'UnloadWave', cinclude'<raylib.h>', nodecl> end -- Unload wave data
+function Raylib.UnloadSound(sound: Sound): void <cimport'UnloadSound', cinclude'<raylib.h>', nodecl> end -- Unload sound
+function Raylib.ExportWave(wave: Wave, fileName: cstring): void <cimport'ExportWave', cinclude'<raylib.h>', nodecl> end -- Export wave data to file
+function Raylib.ExportWaveAsCode(wave: Wave, fileName: cstring): void <cimport'ExportWaveAsCode', cinclude'<raylib.h>', nodecl> end -- Export wave sample data to code (.h)
 
 -- Wave/Sound management functions
-function Raylib.PlaySound(sound: Sound): void <cimport'PlaySound', nodecl> end -- Play a sound
-function Raylib.StopSound(sound: Sound): void <cimport'StopSound', nodecl> end -- Stop playing a sound
-function Raylib.PauseSound(sound: Sound): void <cimport'PauseSound', nodecl> end -- Pause a sound
-function Raylib.ResumeSound(sound: Sound): void <cimport'ResumeSound', nodecl> end -- Resume a paused sound
-function Raylib.PlaySoundMulti(sound: Sound): void <cimport'PlaySoundMulti', nodecl> end -- Play a sound (using multichannel buffer pool)
-function Raylib.StopSoundMulti(): void <cimport'StopSoundMulti', nodecl> end -- Stop any sound playing (using multichannel buffer pool)
-function Raylib.GetSoundsPlaying(): cint <cimport'GetSoundsPlaying', nodecl> end -- Get number of sounds playing in the multichannel
-function Raylib.IsSoundPlaying(sound: Sound): boolean <cimport'IsSoundPlaying', nodecl> end -- Check if a sound is currently playing
-function Raylib.SetSoundVolume(sound: Sound, volume: float32): void <cimport'SetSoundVolume', nodecl> end -- Set volume for a sound (1.0 is max level)
-function Raylib.SetSoundPitch(sound: Sound, pitch: float32): void <cimport'SetSoundPitch', nodecl> end -- Set pitch for a sound (1.0 is base level)
-function Raylib.WaveFormat(wave: Wave*, sampleRate: cint, sampleSize: cint, channels: cint): void <cimport'WaveFormat', nodecl> end -- Convert wave data to desired format
-function Raylib.WaveCopy(wave: Wave): Wave <cimport'WaveCopy', nodecl> end -- Copy a wave to a new wave
-function Raylib.WaveCrop(wave: Wave*, initSample: cint, finalSample: cint): void <cimport'WaveCrop', nodecl> end -- Crop a wave to defined samples range
-function Raylib.GetWaveData(wave: Wave): float32[0]* <cimport'GetWaveData', nodecl> end -- Get samples data from wave as a floats array
+function Raylib.PlaySound(sound: Sound): void <cimport'PlaySound', cinclude'<raylib.h>', nodecl> end -- Play a sound
+function Raylib.StopSound(sound: Sound): void <cimport'StopSound', cinclude'<raylib.h>', nodecl> end -- Stop playing a sound
+function Raylib.PauseSound(sound: Sound): void <cimport'PauseSound', cinclude'<raylib.h>', nodecl> end -- Pause a sound
+function Raylib.ResumeSound(sound: Sound): void <cimport'ResumeSound', cinclude'<raylib.h>', nodecl> end -- Resume a paused sound
+function Raylib.PlaySoundMulti(sound: Sound): void <cimport'PlaySoundMulti', cinclude'<raylib.h>', nodecl> end -- Play a sound (using multichannel buffer pool)
+function Raylib.StopSoundMulti(): void <cimport'StopSoundMulti', cinclude'<raylib.h>', nodecl> end -- Stop any sound playing (using multichannel buffer pool)
+function Raylib.GetSoundsPlaying(): cint <cimport'GetSoundsPlaying', cinclude'<raylib.h>', nodecl> end -- Get number of sounds playing in the multichannel
+function Raylib.IsSoundPlaying(sound: Sound): boolean <cimport'IsSoundPlaying', cinclude'<raylib.h>', nodecl> end -- Check if a sound is currently playing
+function Raylib.SetSoundVolume(sound: Sound, volume: float32): void <cimport'SetSoundVolume', cinclude'<raylib.h>', nodecl> end -- Set volume for a sound (1.0 is max level)
+function Raylib.SetSoundPitch(sound: Sound, pitch: float32): void <cimport'SetSoundPitch', cinclude'<raylib.h>', nodecl> end -- Set pitch for a sound (1.0 is base level)
+function Raylib.WaveFormat(wave: *Wave, sampleRate: cint, sampleSize: cint, channels: cint): void <cimport'WaveFormat', cinclude'<raylib.h>', nodecl> end -- Convert wave data to desired format
+function Wave.Format(wave: *Wave, sampleRate: cint, sampleSize: cint, channels: cint): void <cimport'WaveFormat', cinclude'<raylib.h>', nodecl> end -- Convert wave data to desired format
+
+function Raylib.WaveCopy(wave: Wave): Wave <cimport'WaveCopy', cinclude'<raylib.h>', nodecl> end -- Copy a wave to a new wave
+function Wave.Copy(wave: Wave): Wave <cimport'WaveCopy', cinclude'<raylib.h>', nodecl> end -- Copy a wave to a new wave
+
+function Raylib.WaveCrop(wave: *Wave, initSample: cint, finalSample: cint): void <cimport'WaveCrop', cinclude'<raylib.h>', nodecl> end -- Crop a wave to defined samples range
+function Wave.Crop(wave: *Wave, initSample: cint, finalSample: cint): void <cimport'WaveCrop', cinclude'<raylib.h>', nodecl> end -- Crop a wave to defined samples range
+
+function Raylib.GetWaveData(wave: Wave): *[0]float32 <cimport'GetWaveData', cinclude'<raylib.h>', nodecl> end -- Get samples data from wave as a floats array
 
 -- Music management functions
-function Raylib.LoadMusicStream(fileName: cstring): Music <cimport'LoadMusicStream', nodecl> end -- Load music stream from file
-function Raylib.UnloadMusicStream(music: Music): void <cimport'UnloadMusicStream', nodecl> end -- Unload music stream
-function Raylib.PlayMusicStream(music: Music): void <cimport'PlayMusicStream', nodecl> end -- Start music playing
-function Raylib.UpdateMusicStream(music: Music): void <cimport'UpdateMusicStream', nodecl> end -- Updates buffers for music streaming
-function Raylib.StopMusicStream(music: Music): void <cimport'StopMusicStream', nodecl> end -- Stop music playing
-function Raylib.PauseMusicStream(music: Music): void <cimport'PauseMusicStream', nodecl> end -- Pause music playing
-function Raylib.ResumeMusicStream(music: Music): void <cimport'ResumeMusicStream', nodecl> end -- Resume playing paused music
-function Raylib.IsMusicPlaying(music: Music): boolean <cimport'IsMusicPlaying', nodecl> end -- Check if music is playing
-function Raylib.SetMusicVolume(music: Music, volume: float32): void <cimport'SetMusicVolume', nodecl> end -- Set volume for music (1.0 is max level)
-function Raylib.SetMusicPitch(music: Music, pitch: float32): void <cimport'SetMusicPitch', nodecl> end -- Set pitch for a music (1.0 is base level)
-function Raylib.SetMusicLoopCount(music: Music, count: cint): void <cimport'SetMusicLoopCount', nodecl> end -- Set music loop count (loop repeats)
-function Raylib.GetMusicTimeLength(music: Music): float32 <cimport'GetMusicTimeLength', nodecl> end -- Get music time length (in seconds)
-function Raylib.GetMusicTimePlayed(music: Music): float32 <cimport'GetMusicTimePlayed', nodecl> end -- Get current music time played (in seconds)
+function Raylib.LoadMusicStream(fileName: cstring): Music <cimport'LoadMusicStream', cinclude'<raylib.h>', nodecl> end -- Load music stream from file
+function Raylib.UnloadMusicStream(music: Music): void <cimport'UnloadMusicStream', cinclude'<raylib.h>', nodecl> end -- Unload music stream
+function Raylib.PlayMusicStream(music: Music): void <cimport'PlayMusicStream', cinclude'<raylib.h>', nodecl> end -- Start music playing
+function Raylib.UpdateMusicStream(music: Music): void <cimport'UpdateMusicStream', cinclude'<raylib.h>', nodecl> end -- Updates buffers for music streaming
+function Raylib.StopMusicStream(music: Music): void <cimport'StopMusicStream', cinclude'<raylib.h>', nodecl> end -- Stop music playing
+function Raylib.PauseMusicStream(music: Music): void <cimport'PauseMusicStream', cinclude'<raylib.h>', nodecl> end -- Pause music playing
+function Raylib.ResumeMusicStream(music: Music): void <cimport'ResumeMusicStream', cinclude'<raylib.h>', nodecl> end -- Resume playing paused music
+function Raylib.IsMusicPlaying(music: Music): boolean <cimport'IsMusicPlaying', cinclude'<raylib.h>', nodecl> end -- Check if music is playing
+function Raylib.SetMusicVolume(music: Music, volume: float32): void <cimport'SetMusicVolume', cinclude'<raylib.h>', nodecl> end -- Set volume for music (1.0 is max level)
+function Raylib.SetMusicPitch(music: Music, pitch: float32): void <cimport'SetMusicPitch', cinclude'<raylib.h>', nodecl> end -- Set pitch for a music (1.0 is base level)
+function Raylib.SetMusicLoopCount(music: Music, count: cint): void <cimport'SetMusicLoopCount', cinclude'<raylib.h>', nodecl> end -- Set music loop count (loop repeats)
+function Raylib.GetMusicTimeLength(music: Music): float32 <cimport'GetMusicTimeLength', cinclude'<raylib.h>', nodecl> end -- Get music time length (in seconds)
+function Raylib.GetMusicTimePlayed(music: Music): float32 <cimport'GetMusicTimePlayed', cinclude'<raylib.h>', nodecl> end -- Get current music time played (in seconds)
 
 -- AudioStream management functions
-function Raylib.InitAudioStream(sampleRate: cuint, sampleSize: cuint, channels: cuint): AudioStream <cimport'InitAudioStream', nodecl> end -- Init audio stream (to stream raw audio pcm data)
-function Raylib.UpdateAudioStream(stream: AudioStream, data: pointer, samplesCount: cint): void <cimport'UpdateAudioStream', nodecl> end -- Update audio stream buffers with data
-function Raylib.CloseAudioStream(stream: AudioStream): void <cimport'CloseAudioStream', nodecl> end -- Close audio stream and free memory
-function Raylib.IsAudioStreamProcessed(stream: AudioStream): boolean <cimport'IsAudioStreamProcessed', nodecl> end -- Check if any audio stream buffers requires refill
-function Raylib.PlayAudioStream(stream: AudioStream): void <cimport'PlayAudioStream', nodecl> end -- Play audio stream
-function Raylib.PauseAudioStream(stream: AudioStream): void <cimport'PauseAudioStream', nodecl> end -- Pause audio stream
-function Raylib.ResumeAudioStream(stream: AudioStream): void <cimport'ResumeAudioStream', nodecl> end -- Resume audio stream
-function Raylib.IsAudioStreamPlaying(stream: AudioStream): boolean <cimport'IsAudioStreamPlaying', nodecl> end -- Check if audio stream is playing
-function Raylib.StopAudioStream(stream: AudioStream): void <cimport'StopAudioStream', nodecl> end -- Stop audio stream
-function Raylib.SetAudioStreamVolume(stream: AudioStream, volume: float32): void <cimport'SetAudioStreamVolume', nodecl> end -- Set volume for audio stream (1.0 is max level)
-function Raylib.SetAudioStreamPitch(stream: AudioStream, pitch: float32): void <cimport'SetAudioStreamPitch', nodecl> end -- Set pitch for audio stream (1.0 is base level)
-function Raylib.SetAudioStreamBufferSizeDefault(size: cint): void <cimport'SetAudioStreamBufferSizeDefault', nodecl> end -- Default size for new audio streams
+function Raylib.InitAudioStream(sampleRate: cuint, sampleSize: cuint, channels: cuint): AudioStream <cimport'InitAudioStream', cinclude'<raylib.h>', nodecl> end -- Init audio stream (to stream raw audio pcm data)
+function Raylib.UpdateAudioStream(stream: AudioStream, data: pointer, samplesCount: cint): void <cimport'UpdateAudioStream', cinclude'<raylib.h>', nodecl> end -- Update audio stream buffers with data
+function Raylib.CloseAudioStream(stream: AudioStream): void <cimport'CloseAudioStream', cinclude'<raylib.h>', nodecl> end -- Close audio stream and free memory
+function Raylib.IsAudioStreamProcessed(stream: AudioStream): boolean <cimport'IsAudioStreamProcessed', cinclude'<raylib.h>', nodecl> end -- Check if any audio stream buffers requires refill
+function Raylib.PlayAudioStream(stream: AudioStream): void <cimport'PlayAudioStream', cinclude'<raylib.h>', nodecl> end -- Play audio stream
+function Raylib.PauseAudioStream(stream: AudioStream): void <cimport'PauseAudioStream', cinclude'<raylib.h>', nodecl> end -- Pause audio stream
+function Raylib.ResumeAudioStream(stream: AudioStream): void <cimport'ResumeAudioStream', cinclude'<raylib.h>', nodecl> end -- Resume audio stream
+function Raylib.IsAudioStreamPlaying(stream: AudioStream): boolean <cimport'IsAudioStreamPlaying', cinclude'<raylib.h>', nodecl> end -- Check if audio stream is playing
+function Raylib.StopAudioStream(stream: AudioStream): void <cimport'StopAudioStream', cinclude'<raylib.h>', nodecl> end -- Stop audio stream
+function Raylib.SetAudioStreamVolume(stream: AudioStream, volume: float32): void <cimport'SetAudioStreamVolume', cinclude'<raylib.h>', nodecl> end -- Set volume for audio stream (1.0 is max level)
+function Raylib.SetAudioStreamPitch(stream: AudioStream, pitch: float32): void <cimport'SetAudioStreamPitch', cinclude'<raylib.h>', nodecl> end -- Set pitch for audio stream (1.0 is base level)
+function Raylib.SetAudioStreamBufferSizeDefault(size: cint): void <cimport'SetAudioStreamBufferSizeDefault', cinclude'<raylib.h>', nodecl> end -- Default size for new audio streams
 
 
 
 -- (raylib-nelua modification, colors defines moved to end)
 -- Some Basic Colors
 -- NOTE: Custom raylib color palette for amazing visuals on WHITE background
-global LIGHTGRAY: Color <cimport, nodecl>   -- Light Gray
-global GRAY: Color <cimport, nodecl>   -- Gray
-global DARKGRAY: Color <cimport, nodecl>      -- Dark Gray
-global YELLOW: Color <cimport, nodecl>     -- Yellow
-global GOLD: Color <cimport, nodecl>     -- Gold
-global ORANGE: Color <cimport, nodecl>     -- Orange
-global PINK: Color <cimport, nodecl>   -- Pink
-global RED: Color <cimport, nodecl>     -- Red
-global MAROON: Color <cimport, nodecl>     -- Maroon
-global GREEN: Color <cimport, nodecl>      -- Green
-global LIME: Color <cimport, nodecl>      -- Lime
-global DARKGREEN: Color <cimport, nodecl>      -- Dark Green
-global SKYBLUE: Color <cimport, nodecl>   -- Sky Blue
-global BLUE: Color <cimport, nodecl>     -- Blue
-global DARKBLUE: Color <cimport, nodecl>      -- Dark Blue
-global PURPLE: Color <cimport, nodecl>   -- Purple
-global VIOLET: Color <cimport, nodecl>    -- Violet
-global DARKPURPLE: Color <cimport, nodecl>    -- Dark Purple
-global BEIGE: Color <cimport, nodecl>   -- Beige
-global BROWN: Color <cimport, nodecl>    -- Brown
-global DARKBROWN: Color <cimport, nodecl>      -- Dark Brown
+global LIGHTGRAY: Color <cimport, cinclude'<raylib.h>', nodecl>   -- Light Gray
+global GRAY: Color <cimport, cinclude'<raylib.h>', nodecl>   -- Gray
+global DARKGRAY: Color <cimport, cinclude'<raylib.h>', nodecl>      -- Dark Gray
+global YELLOW: Color <cimport, cinclude'<raylib.h>', nodecl>     -- Yellow
+global GOLD: Color <cimport, cinclude'<raylib.h>', nodecl>     -- Gold
+global ORANGE: Color <cimport, cinclude'<raylib.h>', nodecl>     -- Orange
+global PINK: Color <cimport, cinclude'<raylib.h>', nodecl>   -- Pink
+global RED: Color <cimport, cinclude'<raylib.h>', nodecl>     -- Red
+global MAROON: Color <cimport, cinclude'<raylib.h>', nodecl>     -- Maroon
+global GREEN: Color <cimport, cinclude'<raylib.h>', nodecl>      -- Green
+global LIME: Color <cimport, cinclude'<raylib.h>', nodecl>      -- Lime
+global DARKGREEN: Color <cimport, cinclude'<raylib.h>', nodecl>      -- Dark Green
+global SKYBLUE: Color <cimport, cinclude'<raylib.h>', nodecl>   -- Sky Blue
+global BLUE: Color <cimport, cinclude'<raylib.h>', nodecl>     -- Blue
+global DARKBLUE: Color <cimport, cinclude'<raylib.h>', nodecl>      -- Dark Blue
+global PURPLE: Color <cimport, cinclude'<raylib.h>', nodecl>   -- Purple
+global VIOLET: Color <cimport, cinclude'<raylib.h>', nodecl>    -- Violet
+global DARKPURPLE: Color <cimport, cinclude'<raylib.h>', nodecl>    -- Dark Purple
+global BEIGE: Color <cimport, cinclude'<raylib.h>', nodecl>   -- Beige
+global BROWN: Color <cimport, cinclude'<raylib.h>', nodecl>    -- Brown
+global DARKBROWN: Color <cimport, cinclude'<raylib.h>', nodecl>      -- Dark Brown
 
-global WHITE: Color <cimport, nodecl>   -- White
-global BLACK: Color <cimport, nodecl>         -- Black
-global BLANK: Color <cimport, nodecl>           -- Blank (Transparent)
-global MAGENTA: Color <cimport, nodecl>     -- Magenta
-global RAYWHITE: Color <cimport, nodecl>   -- My own White (raylib logo)
+global WHITE: Color <cimport, cinclude'<raylib.h>', nodecl>   -- White
+global BLACK: Color <cimport, cinclude'<raylib.h>', nodecl>         -- Black
+global BLANK: Color <cimport, cinclude'<raylib.h>', nodecl>           -- Blank (Transparent)
+global MAGENTA: Color <cimport, cinclude'<raylib.h>', nodecl>     -- Magenta
+global RAYWHITE: Color <cimport, cinclude'<raylib.h>', nodecl>   -- My own White (raylib logo)
 
--- raymath binding:
+-- raymath binding: 
 global Raymath = @record{}
 
 
 
 -- NOTE: Helper types to be used instead of array return types for *ToFloat functions
-global float3 <cimport, nodecl> = @record{
-  v : float32[3], }
+global float3 <cimport, cinclude'<raymath.h>', nodecl> = @record{
+  v : [3]float32, }
 ## float3.value.is_float3 = true
-global float16 <cimport, nodecl> = @record{
-  v : float32[16], }
+global float16 <cimport, cinclude'<raymath.h>', nodecl> = @record{
+  v : [16]float32, }
 ## float16.value.is_float16 = true
 
 -- ----------------------------------------------------------------------------------
@@ -1394,342 +1492,419 @@ global float16 <cimport, nodecl> = @record{
 -- ----------------------------------------------------------------------------------
 
 -- Clamp float value
-function Raymath.Clamp(value: float32, min: float32, max: float32): float32 <cimport'Clamp', nodecl> end
+function Raymath.Clamp(value: float32, min: float32, max: float32): float32 <cimport'Clamp', cinclude'<raymath.h>', nodecl> end 
 
 -- Calculate linear interpolation between two floats
-function Raymath.Lerp(start: float32, _end: float32, amount: float32): float32 <cimport'Lerp', nodecl> end
+function Raymath.Lerp(start: float32, _end: float32, amount: float32): float32 <cimport'Lerp', cinclude'<raymath.h>', nodecl> end 
 
 -- ----------------------------------------------------------------------------------
 -- Module Functions Definition - Vector2 math
 -- ----------------------------------------------------------------------------------
 
 -- Vector with components value 0.0f
-function Raymath.Vector2Zero(): Vector2 <cimport'Vector2Zero', nodecl> end
-function Vector2.Zero(): Vector2 <cimport'Vector2Zero', nodecl> end
+function Raymath.Vector2Zero(): Vector2 <cimport'Vector2Zero', cinclude'<raymath.h>', nodecl> end 
+function Vector2.Zero(): Vector2 <cimport'Vector2Zero', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Vector with components value 1.0f
-function Raymath.Vector2One(): Vector2 <cimport'Vector2One', nodecl> end
-function Vector2.One(): Vector2 <cimport'Vector2One', nodecl> end
+function Raymath.Vector2One(): Vector2 <cimport'Vector2One', cinclude'<raymath.h>', nodecl> end 
+function Vector2.One(): Vector2 <cimport'Vector2One', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Add two vectors (v1 + v2)
-function Raymath.Vector2Add(v1: Vector2, v2: Vector2): Vector2 <cimport'Vector2Add', nodecl> end
-function Vector2.Add(v1: Vector2, v2: Vector2): Vector2 <cimport'Vector2Add', nodecl> end
+function Raymath.Vector2Add(v1: Vector2, v2: Vector2): Vector2 <cimport'Vector2Add', cinclude'<raymath.h>', nodecl> end 
+function Vector2.Add(v1: Vector2, v2: Vector2): Vector2 <cimport'Vector2Add', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Subtract two vectors (v1 - v2)
-function Raymath.Vector2Subtract(v1: Vector2, v2: Vector2): Vector2 <cimport'Vector2Subtract', nodecl> end
-function Vector2.Subtract(v1: Vector2, v2: Vector2): Vector2 <cimport'Vector2Subtract', nodecl> end
+function Raymath.Vector2Subtract(v1: Vector2, v2: Vector2): Vector2 <cimport'Vector2Subtract', cinclude'<raymath.h>', nodecl> end 
+function Vector2.Subtract(v1: Vector2, v2: Vector2): Vector2 <cimport'Vector2Subtract', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Calculate vector length
-function Raymath.Vector2Length(v: Vector2): float32 <cimport'Vector2Length', nodecl> end
-function Vector2.Length(v: Vector2): float32 <cimport'Vector2Length', nodecl> end
+function Raymath.Vector2Length(v: Vector2): float32 <cimport'Vector2Length', cinclude'<raymath.h>', nodecl> end 
+function Vector2.Length(v: Vector2): float32 <cimport'Vector2Length', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Calculate two vectors dot product
-function Raymath.Vector2DotProduct(v1: Vector2, v2: Vector2): float32 <cimport'Vector2DotProduct', nodecl> end
-function Vector2.DotProduct(v1: Vector2, v2: Vector2): float32 <cimport'Vector2DotProduct', nodecl> end
+function Raymath.Vector2DotProduct(v1: Vector2, v2: Vector2): float32 <cimport'Vector2DotProduct', cinclude'<raymath.h>', nodecl> end 
+function Vector2.DotProduct(v1: Vector2, v2: Vector2): float32 <cimport'Vector2DotProduct', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Calculate distance between two vectors
-function Raymath.Vector2Distance(v1: Vector2, v2: Vector2): float32 <cimport'Vector2Distance', nodecl> end
-function Vector2.Distance(v1: Vector2, v2: Vector2): float32 <cimport'Vector2Distance', nodecl> end
+function Raymath.Vector2Distance(v1: Vector2, v2: Vector2): float32 <cimport'Vector2Distance', cinclude'<raymath.h>', nodecl> end 
+function Vector2.Distance(v1: Vector2, v2: Vector2): float32 <cimport'Vector2Distance', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Calculate angle from two vectors in X-axis
-function Raymath.Vector2Angle(v1: Vector2, v2: Vector2): float32 <cimport'Vector2Angle', nodecl> end
-function Vector2.Angle(v1: Vector2, v2: Vector2): float32 <cimport'Vector2Angle', nodecl> end
+function Raymath.Vector2Angle(v1: Vector2, v2: Vector2): float32 <cimport'Vector2Angle', cinclude'<raymath.h>', nodecl> end 
+function Vector2.Angle(v1: Vector2, v2: Vector2): float32 <cimport'Vector2Angle', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Scale vector (multiply by value)
-function Raymath.Vector2Scale(v: Vector2, scale: float32): Vector2 <cimport'Vector2Scale', nodecl> end
-function Vector2.Scale(v: Vector2, scale: float32): Vector2 <cimport'Vector2Scale', nodecl> end
+function Raymath.Vector2Scale(v: Vector2, scale: float32): Vector2 <cimport'Vector2Scale', cinclude'<raymath.h>', nodecl> end 
+function Vector2.Scale(v: Vector2, scale: float32): Vector2 <cimport'Vector2Scale', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Multiply vector by vector
-function Raymath.Vector2MultiplyV(v1: Vector2, v2: Vector2): Vector2 <cimport'Vector2MultiplyV', nodecl> end
-function Vector2.MultiplyV(v1: Vector2, v2: Vector2): Vector2 <cimport'Vector2MultiplyV', nodecl> end
+function Raymath.Vector2MultiplyV(v1: Vector2, v2: Vector2): Vector2 <cimport'Vector2MultiplyV', cinclude'<raymath.h>', nodecl> end 
+function Vector2.MultiplyV(v1: Vector2, v2: Vector2): Vector2 <cimport'Vector2MultiplyV', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Negate vector
-function Raymath.Vector2Negate(v: Vector2): Vector2 <cimport'Vector2Negate', nodecl> end
-function Vector2.Negate(v: Vector2): Vector2 <cimport'Vector2Negate', nodecl> end
+function Raymath.Vector2Negate(v: Vector2): Vector2 <cimport'Vector2Negate', cinclude'<raymath.h>', nodecl> end 
+function Vector2.Negate(v: Vector2): Vector2 <cimport'Vector2Negate', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Divide vector by a float value
-function Raymath.Vector2Divide(v: Vector2, div: float32): Vector2 <cimport'Vector2Divide', nodecl> end
-function Vector2.Divide(v: Vector2, div: float32): Vector2 <cimport'Vector2Divide', nodecl> end
+function Raymath.Vector2Divide(v: Vector2, div: float32): Vector2 <cimport'Vector2Divide', cinclude'<raymath.h>', nodecl> end 
+function Vector2.Divide(v: Vector2, div: float32): Vector2 <cimport'Vector2Divide', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Divide vector by vector
-function Raymath.Vector2DivideV(v1: Vector2, v2: Vector2): Vector2 <cimport'Vector2DivideV', nodecl> end
-function Vector2.DivideV(v1: Vector2, v2: Vector2): Vector2 <cimport'Vector2DivideV', nodecl> end
+function Raymath.Vector2DivideV(v1: Vector2, v2: Vector2): Vector2 <cimport'Vector2DivideV', cinclude'<raymath.h>', nodecl> end 
+function Vector2.DivideV(v1: Vector2, v2: Vector2): Vector2 <cimport'Vector2DivideV', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Normalize provided vector
-function Raymath.Vector2Normalize(v: Vector2): Vector2 <cimport'Vector2Normalize', nodecl> end
-function Vector2.Normalize(v: Vector2): Vector2 <cimport'Vector2Normalize', nodecl> end
+function Raymath.Vector2Normalize(v: Vector2): Vector2 <cimport'Vector2Normalize', cinclude'<raymath.h>', nodecl> end 
+function Vector2.Normalize(v: Vector2): Vector2 <cimport'Vector2Normalize', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Calculate linear interpolation between two vectors
-function Raymath.Vector2Lerp(v1: Vector2, v2: Vector2, amount: float32): Vector2 <cimport'Vector2Lerp', nodecl> end
-function Vector2.Lerp(v1: Vector2, v2: Vector2, amount: float32): Vector2 <cimport'Vector2Lerp', nodecl> end
+function Raymath.Vector2Lerp(v1: Vector2, v2: Vector2, amount: float32): Vector2 <cimport'Vector2Lerp', cinclude'<raymath.h>', nodecl> end 
+function Vector2.Lerp(v1: Vector2, v2: Vector2, amount: float32): Vector2 <cimport'Vector2Lerp', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Rotate Vector by float in Degrees.
-function Raymath.Vector2Rotate(v: Vector2, degs: float32): Vector2 <cimport'Vector2Rotate', nodecl> end
-function Vector2.Rotate(v: Vector2, degs: float32): Vector2 <cimport'Vector2Rotate', nodecl> end
+function Raymath.Vector2Rotate(v: Vector2, degs: float32): Vector2 <cimport'Vector2Rotate', cinclude'<raymath.h>', nodecl> end 
+function Vector2.Rotate(v: Vector2, degs: float32): Vector2 <cimport'Vector2Rotate', cinclude'<raymath.h>', nodecl> end 
+
 
 -- ----------------------------------------------------------------------------------
 -- Module Functions Definition - Vector3 math
 -- ----------------------------------------------------------------------------------
 
 -- Vector with components value 0.0f
-function Raymath.Vector3Zero(): Vector3 <cimport'Vector3Zero', nodecl> end
-function Vector3.Zero(): Vector3 <cimport'Vector3Zero', nodecl> end
+function Raymath.Vector3Zero(): Vector3 <cimport'Vector3Zero', cinclude'<raymath.h>', nodecl> end 
+function Vector3.Zero(): Vector3 <cimport'Vector3Zero', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Vector with components value 1.0f
-function Raymath.Vector3One(): Vector3 <cimport'Vector3One', nodecl> end
-function Vector3.One(): Vector3 <cimport'Vector3One', nodecl> end
+function Raymath.Vector3One(): Vector3 <cimport'Vector3One', cinclude'<raymath.h>', nodecl> end 
+function Vector3.One(): Vector3 <cimport'Vector3One', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Add two vectors
-function Raymath.Vector3Add(v1: Vector3, v2: Vector3): Vector3 <cimport'Vector3Add', nodecl> end
-function Vector3.Add(v1: Vector3, v2: Vector3): Vector3 <cimport'Vector3Add', nodecl> end
+function Raymath.Vector3Add(v1: Vector3, v2: Vector3): Vector3 <cimport'Vector3Add', cinclude'<raymath.h>', nodecl> end 
+function Vector3.Add(v1: Vector3, v2: Vector3): Vector3 <cimport'Vector3Add', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Subtract two vectors
-function Raymath.Vector3Subtract(v1: Vector3, v2: Vector3): Vector3 <cimport'Vector3Subtract', nodecl> end
-function Vector3.Subtract(v1: Vector3, v2: Vector3): Vector3 <cimport'Vector3Subtract', nodecl> end
+function Raymath.Vector3Subtract(v1: Vector3, v2: Vector3): Vector3 <cimport'Vector3Subtract', cinclude'<raymath.h>', nodecl> end 
+function Vector3.Subtract(v1: Vector3, v2: Vector3): Vector3 <cimport'Vector3Subtract', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Multiply vector by scalar
-function Raymath.Vector3Scale(v: Vector3, scalar: float32): Vector3 <cimport'Vector3Scale', nodecl> end
-function Vector3.Scale(v: Vector3, scalar: float32): Vector3 <cimport'Vector3Scale', nodecl> end
+function Raymath.Vector3Scale(v: Vector3, scalar: float32): Vector3 <cimport'Vector3Scale', cinclude'<raymath.h>', nodecl> end 
+function Vector3.Scale(v: Vector3, scalar: float32): Vector3 <cimport'Vector3Scale', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Multiply vector by vector
-function Raymath.Vector3Multiply(v1: Vector3, v2: Vector3): Vector3 <cimport'Vector3Multiply', nodecl> end
-function Vector3.Multiply(v1: Vector3, v2: Vector3): Vector3 <cimport'Vector3Multiply', nodecl> end
+function Raymath.Vector3Multiply(v1: Vector3, v2: Vector3): Vector3 <cimport'Vector3Multiply', cinclude'<raymath.h>', nodecl> end 
+function Vector3.Multiply(v1: Vector3, v2: Vector3): Vector3 <cimport'Vector3Multiply', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Calculate two vectors cross product
-function Raymath.Vector3CrossProduct(v1: Vector3, v2: Vector3): Vector3 <cimport'Vector3CrossProduct', nodecl> end
-function Vector3.CrossProduct(v1: Vector3, v2: Vector3): Vector3 <cimport'Vector3CrossProduct', nodecl> end
+function Raymath.Vector3CrossProduct(v1: Vector3, v2: Vector3): Vector3 <cimport'Vector3CrossProduct', cinclude'<raymath.h>', nodecl> end 
+function Vector3.CrossProduct(v1: Vector3, v2: Vector3): Vector3 <cimport'Vector3CrossProduct', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Calculate one vector perpendicular vector
-function Raymath.Vector3Perpendicular(v: Vector3): Vector3 <cimport'Vector3Perpendicular', nodecl> end
-function Vector3.Perpendicular(v: Vector3): Vector3 <cimport'Vector3Perpendicular', nodecl> end
+function Raymath.Vector3Perpendicular(v: Vector3): Vector3 <cimport'Vector3Perpendicular', cinclude'<raymath.h>', nodecl> end 
+function Vector3.Perpendicular(v: Vector3): Vector3 <cimport'Vector3Perpendicular', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Calculate vector length
-function Raymath.Vector3Length(v: Vector3): float32 <cimport'Vector3Length', nodecl> end
-function Vector3.Length(v: Vector3): float32 <cimport'Vector3Length', nodecl> end
+function Raymath.Vector3Length(v: Vector3): float32 <cimport'Vector3Length', cinclude'<raymath.h>', nodecl> end 
+function Vector3.Length(v: Vector3): float32 <cimport'Vector3Length', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Calculate two vectors dot product
-function Raymath.Vector3DotProduct(v1: Vector3, v2: Vector3): float32 <cimport'Vector3DotProduct', nodecl> end
-function Vector3.DotProduct(v1: Vector3, v2: Vector3): float32 <cimport'Vector3DotProduct', nodecl> end
+function Raymath.Vector3DotProduct(v1: Vector3, v2: Vector3): float32 <cimport'Vector3DotProduct', cinclude'<raymath.h>', nodecl> end 
+function Vector3.DotProduct(v1: Vector3, v2: Vector3): float32 <cimport'Vector3DotProduct', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Calculate distance between two vectors
-function Raymath.Vector3Distance(v1: Vector3, v2: Vector3): float32 <cimport'Vector3Distance', nodecl> end
-function Vector3.Distance(v1: Vector3, v2: Vector3): float32 <cimport'Vector3Distance', nodecl> end
+function Raymath.Vector3Distance(v1: Vector3, v2: Vector3): float32 <cimport'Vector3Distance', cinclude'<raymath.h>', nodecl> end 
+function Vector3.Distance(v1: Vector3, v2: Vector3): float32 <cimport'Vector3Distance', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Negate provided vector (invert direction)
-function Raymath.Vector3Negate(v: Vector3): Vector3 <cimport'Vector3Negate', nodecl> end
-function Vector3.Negate(v: Vector3): Vector3 <cimport'Vector3Negate', nodecl> end
+function Raymath.Vector3Negate(v: Vector3): Vector3 <cimport'Vector3Negate', cinclude'<raymath.h>', nodecl> end 
+function Vector3.Negate(v: Vector3): Vector3 <cimport'Vector3Negate', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Divide vector by a float value
-function Raymath.Vector3Divide(v: Vector3, div: float32): Vector3 <cimport'Vector3Divide', nodecl> end
-function Vector3.Divide(v: Vector3, div: float32): Vector3 <cimport'Vector3Divide', nodecl> end
+function Raymath.Vector3Divide(v: Vector3, div: float32): Vector3 <cimport'Vector3Divide', cinclude'<raymath.h>', nodecl> end 
+function Vector3.Divide(v: Vector3, div: float32): Vector3 <cimport'Vector3Divide', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Divide vector by vector
-function Raymath.Vector3DivideV(v1: Vector3, v2: Vector3): Vector3 <cimport'Vector3DivideV', nodecl> end
-function Vector3.DivideV(v1: Vector3, v2: Vector3): Vector3 <cimport'Vector3DivideV', nodecl> end
+function Raymath.Vector3DivideV(v1: Vector3, v2: Vector3): Vector3 <cimport'Vector3DivideV', cinclude'<raymath.h>', nodecl> end 
+function Vector3.DivideV(v1: Vector3, v2: Vector3): Vector3 <cimport'Vector3DivideV', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Normalize provided vector
-function Raymath.Vector3Normalize(v: Vector3): Vector3 <cimport'Vector3Normalize', nodecl> end
-function Vector3.Normalize(v: Vector3): Vector3 <cimport'Vector3Normalize', nodecl> end
+function Raymath.Vector3Normalize(v: Vector3): Vector3 <cimport'Vector3Normalize', cinclude'<raymath.h>', nodecl> end 
+function Vector3.Normalize(v: Vector3): Vector3 <cimport'Vector3Normalize', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Orthonormalize provided vectors
 -- Makes vectors normalized and orthogonal to each other
 -- Gram-Schmidt function implementation
-function Raymath.Vector3OrthoNormalize(v1: Vector3*, v2: Vector3*): void <cimport'Vector3OrthoNormalize', nodecl> end
-function Vector3.OrthoNormalize(v1: Vector3*, v2: Vector3*): void <cimport'Vector3OrthoNormalize', nodecl> end
+function Raymath.Vector3OrthoNormalize(v1: *Vector3, v2: *Vector3): void <cimport'Vector3OrthoNormalize', cinclude'<raymath.h>', nodecl> end 
+function Vector3.OrthoNormalize(v1: *Vector3, v2: *Vector3): void <cimport'Vector3OrthoNormalize', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Transforms a Vector3 by a given Matrix
-function Raymath.Vector3Transform(v: Vector3, mat: Matrix): Vector3 <cimport'Vector3Transform', nodecl> end
-function Vector3.Transform(v: Vector3, mat: Matrix): Vector3 <cimport'Vector3Transform', nodecl> end
+function Raymath.Vector3Transform(v: Vector3, mat: Matrix): Vector3 <cimport'Vector3Transform', cinclude'<raymath.h>', nodecl> end 
+function Vector3.Transform(v: Vector3, mat: Matrix): Vector3 <cimport'Vector3Transform', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Transform a vector by quaternion rotation
-function Raymath.Vector3RotateByQuaternion(v: Vector3, q: Quaternion): Vector3 <cimport'Vector3RotateByQuaternion', nodecl> end
-function Vector3.RotateByQuaternion(v: Vector3, q: Quaternion): Vector3 <cimport'Vector3RotateByQuaternion', nodecl> end
+function Raymath.Vector3RotateByQuaternion(v: Vector3, q: Quaternion): Vector3 <cimport'Vector3RotateByQuaternion', cinclude'<raymath.h>', nodecl> end 
+function Vector3.RotateByQuaternion(v: Vector3, q: Quaternion): Vector3 <cimport'Vector3RotateByQuaternion', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Calculate linear interpolation between two vectors
-function Raymath.Vector3Lerp(v1: Vector3, v2: Vector3, amount: float32): Vector3 <cimport'Vector3Lerp', nodecl> end
-function Vector3.Lerp(v1: Vector3, v2: Vector3, amount: float32): Vector3 <cimport'Vector3Lerp', nodecl> end
+function Raymath.Vector3Lerp(v1: Vector3, v2: Vector3, amount: float32): Vector3 <cimport'Vector3Lerp', cinclude'<raymath.h>', nodecl> end 
+function Vector3.Lerp(v1: Vector3, v2: Vector3, amount: float32): Vector3 <cimport'Vector3Lerp', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Calculate reflected vector to normal
-function Raymath.Vector3Reflect(v: Vector3, normal: Vector3): Vector3 <cimport'Vector3Reflect', nodecl> end
-function Vector3.Reflect(v: Vector3, normal: Vector3): Vector3 <cimport'Vector3Reflect', nodecl> end
+function Raymath.Vector3Reflect(v: Vector3, normal: Vector3): Vector3 <cimport'Vector3Reflect', cinclude'<raymath.h>', nodecl> end 
+function Vector3.Reflect(v: Vector3, normal: Vector3): Vector3 <cimport'Vector3Reflect', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Return min value for each pair of components
-function Raymath.Vector3Min(v1: Vector3, v2: Vector3): Vector3 <cimport'Vector3Min', nodecl> end
-function Vector3.Min(v1: Vector3, v2: Vector3): Vector3 <cimport'Vector3Min', nodecl> end
+function Raymath.Vector3Min(v1: Vector3, v2: Vector3): Vector3 <cimport'Vector3Min', cinclude'<raymath.h>', nodecl> end 
+function Vector3.Min(v1: Vector3, v2: Vector3): Vector3 <cimport'Vector3Min', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Return max value for each pair of components
-function Raymath.Vector3Max(v1: Vector3, v2: Vector3): Vector3 <cimport'Vector3Max', nodecl> end
-function Vector3.Max(v1: Vector3, v2: Vector3): Vector3 <cimport'Vector3Max', nodecl> end
+function Raymath.Vector3Max(v1: Vector3, v2: Vector3): Vector3 <cimport'Vector3Max', cinclude'<raymath.h>', nodecl> end 
+function Vector3.Max(v1: Vector3, v2: Vector3): Vector3 <cimport'Vector3Max', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Compute barycenter coordinates (u, v, w) for point p with respect to triangle (a, b, c)
 -- NOTE: Assumes P is on the plane of the triangle
-function Raymath.Vector3Barycenter(p: Vector3, a: Vector3, b: Vector3, c: Vector3): Vector3 <cimport'Vector3Barycenter', nodecl> end
-function Vector3.Barycenter(p: Vector3, a: Vector3, b: Vector3, c: Vector3): Vector3 <cimport'Vector3Barycenter', nodecl> end
+function Raymath.Vector3Barycenter(p: Vector3, a: Vector3, b: Vector3, c: Vector3): Vector3 <cimport'Vector3Barycenter', cinclude'<raymath.h>', nodecl> end 
+function Vector3.Barycenter(p: Vector3, a: Vector3, b: Vector3, c: Vector3): Vector3 <cimport'Vector3Barycenter', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Returns Vector3 as float array
-function Raymath.Vector3ToFloatV(v: Vector3): float3 <cimport'Vector3ToFloatV', nodecl> end
-function Vector3.ToFloatV(v: Vector3): float3 <cimport'Vector3ToFloatV', nodecl> end
+function Raymath.Vector3ToFloatV(v: Vector3): float3 <cimport'Vector3ToFloatV', cinclude'<raymath.h>', nodecl> end 
+function Vector3.ToFloatV(v: Vector3): float3 <cimport'Vector3ToFloatV', cinclude'<raymath.h>', nodecl> end 
+
 
 -- ----------------------------------------------------------------------------------
 -- Module Functions Definition - Matrix math
 -- ----------------------------------------------------------------------------------
 
 -- Compute matrix determinant
-function Raymath.MatrixDeterminant(mat: Matrix): float32 <cimport'MatrixDeterminant', nodecl> end
-function Matrix.Determinant(mat: Matrix): float32 <cimport'MatrixDeterminant', nodecl> end
+function Raymath.MatrixDeterminant(mat: Matrix): float32 <cimport'MatrixDeterminant', cinclude'<raymath.h>', nodecl> end 
+function Matrix.Determinant(mat: Matrix): float32 <cimport'MatrixDeterminant', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Returns the trace of the matrix (sum of the values along the diagonal)
-function Raymath.MatrixTrace(mat: Matrix): float32 <cimport'MatrixTrace', nodecl> end
-function Matrix.Trace(mat: Matrix): float32 <cimport'MatrixTrace', nodecl> end
+function Raymath.MatrixTrace(mat: Matrix): float32 <cimport'MatrixTrace', cinclude'<raymath.h>', nodecl> end 
+function Matrix.Trace(mat: Matrix): float32 <cimport'MatrixTrace', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Transposes provided matrix
-function Raymath.MatrixTranspose(mat: Matrix): Matrix <cimport'MatrixTranspose', nodecl> end
-function Matrix.Transpose(mat: Matrix): Matrix <cimport'MatrixTranspose', nodecl> end
+function Raymath.MatrixTranspose(mat: Matrix): Matrix <cimport'MatrixTranspose', cinclude'<raymath.h>', nodecl> end 
+function Matrix.Transpose(mat: Matrix): Matrix <cimport'MatrixTranspose', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Invert provided matrix
-function Raymath.MatrixInvert(mat: Matrix): Matrix <cimport'MatrixInvert', nodecl> end
-function Matrix.Invert(mat: Matrix): Matrix <cimport'MatrixInvert', nodecl> end
+function Raymath.MatrixInvert(mat: Matrix): Matrix <cimport'MatrixInvert', cinclude'<raymath.h>', nodecl> end 
+function Matrix.Invert(mat: Matrix): Matrix <cimport'MatrixInvert', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Normalize provided matrix
-function Raymath.MatrixNormalize(mat: Matrix): Matrix <cimport'MatrixNormalize', nodecl> end
-function Matrix.Normalize(mat: Matrix): Matrix <cimport'MatrixNormalize', nodecl> end
+function Raymath.MatrixNormalize(mat: Matrix): Matrix <cimport'MatrixNormalize', cinclude'<raymath.h>', nodecl> end 
+function Matrix.Normalize(mat: Matrix): Matrix <cimport'MatrixNormalize', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Returns identity matrix
-function Raymath.MatrixIdentity(): Matrix <cimport'MatrixIdentity', nodecl> end
-function Matrix.Identity(): Matrix <cimport'MatrixIdentity', nodecl> end
+function Raymath.MatrixIdentity(): Matrix <cimport'MatrixIdentity', cinclude'<raymath.h>', nodecl> end 
+function Matrix.Identity(): Matrix <cimport'MatrixIdentity', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Add two matrices
-function Raymath.MatrixAdd(left: Matrix, right: Matrix): Matrix <cimport'MatrixAdd', nodecl> end
-function Matrix.Add(left: Matrix, right: Matrix): Matrix <cimport'MatrixAdd', nodecl> end
+function Raymath.MatrixAdd(left: Matrix, right: Matrix): Matrix <cimport'MatrixAdd', cinclude'<raymath.h>', nodecl> end 
+function Matrix.Add(left: Matrix, right: Matrix): Matrix <cimport'MatrixAdd', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Subtract two matrices (left - right)
-function Raymath.MatrixSubtract(left: Matrix, right: Matrix): Matrix <cimport'MatrixSubtract', nodecl> end
-function Matrix.Subtract(left: Matrix, right: Matrix): Matrix <cimport'MatrixSubtract', nodecl> end
+function Raymath.MatrixSubtract(left: Matrix, right: Matrix): Matrix <cimport'MatrixSubtract', cinclude'<raymath.h>', nodecl> end 
+function Matrix.Subtract(left: Matrix, right: Matrix): Matrix <cimport'MatrixSubtract', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Returns translation matrix
-function Raymath.MatrixTranslate(x: float32, y: float32, z: float32): Matrix <cimport'MatrixTranslate', nodecl> end
-function Matrix.Translate(x: float32, y: float32, z: float32): Matrix <cimport'MatrixTranslate', nodecl> end
+function Raymath.MatrixTranslate(x: float32, y: float32, z: float32): Matrix <cimport'MatrixTranslate', cinclude'<raymath.h>', nodecl> end 
+function Matrix.Translate(x: float32, y: float32, z: float32): Matrix <cimport'MatrixTranslate', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Create rotation matrix from axis and angle
 -- NOTE: Angle should be provided in radians
-function Raymath.MatrixRotate(axis: Vector3, angle: float32): Matrix <cimport'MatrixRotate', nodecl> end
-function Matrix.Rotate(axis: Vector3, angle: float32): Matrix <cimport'MatrixRotate', nodecl> end
+function Raymath.MatrixRotate(axis: Vector3, angle: float32): Matrix <cimport'MatrixRotate', cinclude'<raymath.h>', nodecl> end 
+function Matrix.Rotate(axis: Vector3, angle: float32): Matrix <cimport'MatrixRotate', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Returns xyz-rotation matrix (angles in radians)
-function Raymath.MatrixRotateXYZ(ang: Vector3): Matrix <cimport'MatrixRotateXYZ', nodecl> end
-function Matrix.RotateXYZ(ang: Vector3): Matrix <cimport'MatrixRotateXYZ', nodecl> end
+function Raymath.MatrixRotateXYZ(ang: Vector3): Matrix <cimport'MatrixRotateXYZ', cinclude'<raymath.h>', nodecl> end 
+function Matrix.RotateXYZ(ang: Vector3): Matrix <cimport'MatrixRotateXYZ', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Returns x-rotation matrix (angle in radians)
-function Raymath.MatrixRotateX(angle: float32): Matrix <cimport'MatrixRotateX', nodecl> end
-function Matrix.RotateX(angle: float32): Matrix <cimport'MatrixRotateX', nodecl> end
+function Raymath.MatrixRotateX(angle: float32): Matrix <cimport'MatrixRotateX', cinclude'<raymath.h>', nodecl> end 
+function Matrix.RotateX(angle: float32): Matrix <cimport'MatrixRotateX', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Returns y-rotation matrix (angle in radians)
-function Raymath.MatrixRotateY(angle: float32): Matrix <cimport'MatrixRotateY', nodecl> end
-function Matrix.RotateY(angle: float32): Matrix <cimport'MatrixRotateY', nodecl> end
+function Raymath.MatrixRotateY(angle: float32): Matrix <cimport'MatrixRotateY', cinclude'<raymath.h>', nodecl> end 
+function Matrix.RotateY(angle: float32): Matrix <cimport'MatrixRotateY', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Returns z-rotation matrix (angle in radians)
-function Raymath.MatrixRotateZ(angle: float32): Matrix <cimport'MatrixRotateZ', nodecl> end
-function Matrix.RotateZ(angle: float32): Matrix <cimport'MatrixRotateZ', nodecl> end
+function Raymath.MatrixRotateZ(angle: float32): Matrix <cimport'MatrixRotateZ', cinclude'<raymath.h>', nodecl> end 
+function Matrix.RotateZ(angle: float32): Matrix <cimport'MatrixRotateZ', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Returns scaling matrix
-function Raymath.MatrixScale(x: float32, y: float32, z: float32): Matrix <cimport'MatrixScale', nodecl> end
-function Matrix.Scale(x: float32, y: float32, z: float32): Matrix <cimport'MatrixScale', nodecl> end
+function Raymath.MatrixScale(x: float32, y: float32, z: float32): Matrix <cimport'MatrixScale', cinclude'<raymath.h>', nodecl> end 
+function Matrix.Scale(x: float32, y: float32, z: float32): Matrix <cimport'MatrixScale', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Returns two matrix multiplication
 -- NOTE: When multiplying matrices... the order matters!
-function Raymath.MatrixMultiply(left: Matrix, right: Matrix): Matrix <cimport'MatrixMultiply', nodecl> end
-function Matrix.Multiply(left: Matrix, right: Matrix): Matrix <cimport'MatrixMultiply', nodecl> end
+function Raymath.MatrixMultiply(left: Matrix, right: Matrix): Matrix <cimport'MatrixMultiply', cinclude'<raymath.h>', nodecl> end 
+function Matrix.Multiply(left: Matrix, right: Matrix): Matrix <cimport'MatrixMultiply', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Returns perspective projection matrix
-function Raymath.MatrixFrustum(left: float64, right: float64, bottom: float64, top: float64, near: float64, far: float64): Matrix <cimport'MatrixFrustum', nodecl> end
-function Matrix.Frustum(left: float64, right: float64, bottom: float64, top: float64, near: float64, far: float64): Matrix <cimport'MatrixFrustum', nodecl> end
+function Raymath.MatrixFrustum(left: float64, right: float64, bottom: float64, top: float64, near: float64, far: float64): Matrix <cimport'MatrixFrustum', cinclude'<raymath.h>', nodecl> end 
+function Matrix.Frustum(left: float64, right: float64, bottom: float64, top: float64, near: float64, far: float64): Matrix <cimport'MatrixFrustum', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Returns perspective projection matrix
 -- NOTE: Angle should be provided in radians
-function Raymath.MatrixPerspective(fovy: float64, aspect: float64, near: float64, far: float64): Matrix <cimport'MatrixPerspective', nodecl> end
-function Matrix.Perspective(fovy: float64, aspect: float64, near: float64, far: float64): Matrix <cimport'MatrixPerspective', nodecl> end
+function Raymath.MatrixPerspective(fovy: float64, aspect: float64, near: float64, far: float64): Matrix <cimport'MatrixPerspective', cinclude'<raymath.h>', nodecl> end 
+function Matrix.Perspective(fovy: float64, aspect: float64, near: float64, far: float64): Matrix <cimport'MatrixPerspective', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Returns orthographic projection matrix
-function Raymath.MatrixOrtho(left: float64, right: float64, bottom: float64, top: float64, near: float64, far: float64): Matrix <cimport'MatrixOrtho', nodecl> end
-function Matrix.Ortho(left: float64, right: float64, bottom: float64, top: float64, near: float64, far: float64): Matrix <cimport'MatrixOrtho', nodecl> end
+function Raymath.MatrixOrtho(left: float64, right: float64, bottom: float64, top: float64, near: float64, far: float64): Matrix <cimport'MatrixOrtho', cinclude'<raymath.h>', nodecl> end 
+function Matrix.Ortho(left: float64, right: float64, bottom: float64, top: float64, near: float64, far: float64): Matrix <cimport'MatrixOrtho', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Returns camera look-at matrix (view matrix)
-function Raymath.MatrixLookAt(eye: Vector3, target: Vector3, up: Vector3): Matrix <cimport'MatrixLookAt', nodecl> end
-function Matrix.LookAt(eye: Vector3, target: Vector3, up: Vector3): Matrix <cimport'MatrixLookAt', nodecl> end
+function Raymath.MatrixLookAt(eye: Vector3, target: Vector3, up: Vector3): Matrix <cimport'MatrixLookAt', cinclude'<raymath.h>', nodecl> end 
+function Matrix.LookAt(eye: Vector3, target: Vector3, up: Vector3): Matrix <cimport'MatrixLookAt', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Returns float array of matrix data
-function Raymath.MatrixToFloatV(mat: Matrix): float16 <cimport'MatrixToFloatV', nodecl> end
-function Matrix.ToFloatV(mat: Matrix): float16 <cimport'MatrixToFloatV', nodecl> end
+function Raymath.MatrixToFloatV(mat: Matrix): float16 <cimport'MatrixToFloatV', cinclude'<raymath.h>', nodecl> end 
+function Matrix.ToFloatV(mat: Matrix): float16 <cimport'MatrixToFloatV', cinclude'<raymath.h>', nodecl> end 
+
 
 -- ----------------------------------------------------------------------------------
 -- Module Functions Definition - Quaternion math
 -- ----------------------------------------------------------------------------------
 
 -- Returns identity quaternion
-function Raymath.QuaternionIdentity(): Quaternion <cimport'QuaternionIdentity', nodecl> end
-function Quaternion.Identity(): Quaternion <cimport'QuaternionIdentity', nodecl> end
+function Raymath.QuaternionIdentity(): Quaternion <cimport'QuaternionIdentity', cinclude'<raymath.h>', nodecl> end 
+function Quaternion.Identity(): Quaternion <cimport'QuaternionIdentity', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Computes the length of a quaternion
-function Raymath.QuaternionLength(q: Quaternion): float32 <cimport'QuaternionLength', nodecl> end
-function Quaternion.Length(q: Quaternion): float32 <cimport'QuaternionLength', nodecl> end
+function Raymath.QuaternionLength(q: Quaternion): float32 <cimport'QuaternionLength', cinclude'<raymath.h>', nodecl> end 
+function Quaternion.Length(q: Quaternion): float32 <cimport'QuaternionLength', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Normalize provided quaternion
-function Raymath.QuaternionNormalize(q: Quaternion): Quaternion <cimport'QuaternionNormalize', nodecl> end
-function Quaternion.Normalize(q: Quaternion): Quaternion <cimport'QuaternionNormalize', nodecl> end
+function Raymath.QuaternionNormalize(q: Quaternion): Quaternion <cimport'QuaternionNormalize', cinclude'<raymath.h>', nodecl> end 
+function Quaternion.Normalize(q: Quaternion): Quaternion <cimport'QuaternionNormalize', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Invert provided quaternion
-function Raymath.QuaternionInvert(q: Quaternion): Quaternion <cimport'QuaternionInvert', nodecl> end
-function Quaternion.Invert(q: Quaternion): Quaternion <cimport'QuaternionInvert', nodecl> end
+function Raymath.QuaternionInvert(q: Quaternion): Quaternion <cimport'QuaternionInvert', cinclude'<raymath.h>', nodecl> end 
+function Quaternion.Invert(q: Quaternion): Quaternion <cimport'QuaternionInvert', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Calculate two quaternion multiplication
-function Raymath.QuaternionMultiply(q1: Quaternion, q2: Quaternion): Quaternion <cimport'QuaternionMultiply', nodecl> end
-function Quaternion.Multiply(q1: Quaternion, q2: Quaternion): Quaternion <cimport'QuaternionMultiply', nodecl> end
+function Raymath.QuaternionMultiply(q1: Quaternion, q2: Quaternion): Quaternion <cimport'QuaternionMultiply', cinclude'<raymath.h>', nodecl> end 
+function Quaternion.Multiply(q1: Quaternion, q2: Quaternion): Quaternion <cimport'QuaternionMultiply', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Calculate linear interpolation between two quaternions
-function Raymath.QuaternionLerp(q1: Quaternion, q2: Quaternion, amount: float32): Quaternion <cimport'QuaternionLerp', nodecl> end
-function Quaternion.Lerp(q1: Quaternion, q2: Quaternion, amount: float32): Quaternion <cimport'QuaternionLerp', nodecl> end
+function Raymath.QuaternionLerp(q1: Quaternion, q2: Quaternion, amount: float32): Quaternion <cimport'QuaternionLerp', cinclude'<raymath.h>', nodecl> end 
+function Quaternion.Lerp(q1: Quaternion, q2: Quaternion, amount: float32): Quaternion <cimport'QuaternionLerp', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Calculate slerp-optimized interpolation between two quaternions
-function Raymath.QuaternionNlerp(q1: Quaternion, q2: Quaternion, amount: float32): Quaternion <cimport'QuaternionNlerp', nodecl> end
-function Quaternion.Nlerp(q1: Quaternion, q2: Quaternion, amount: float32): Quaternion <cimport'QuaternionNlerp', nodecl> end
+function Raymath.QuaternionNlerp(q1: Quaternion, q2: Quaternion, amount: float32): Quaternion <cimport'QuaternionNlerp', cinclude'<raymath.h>', nodecl> end 
+function Quaternion.Nlerp(q1: Quaternion, q2: Quaternion, amount: float32): Quaternion <cimport'QuaternionNlerp', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Calculates spherical linear interpolation between two quaternions
-function Raymath.QuaternionSlerp(q1: Quaternion, q2: Quaternion, amount: float32): Quaternion <cimport'QuaternionSlerp', nodecl> end
-function Quaternion.Slerp(q1: Quaternion, q2: Quaternion, amount: float32): Quaternion <cimport'QuaternionSlerp', nodecl> end
+function Raymath.QuaternionSlerp(q1: Quaternion, q2: Quaternion, amount: float32): Quaternion <cimport'QuaternionSlerp', cinclude'<raymath.h>', nodecl> end 
+function Quaternion.Slerp(q1: Quaternion, q2: Quaternion, amount: float32): Quaternion <cimport'QuaternionSlerp', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Calculate quaternion based on the rotation from one vector to another
-function Raymath.QuaternionFromVector3ToVector3(from: Vector3, to: Vector3): Quaternion <cimport'QuaternionFromVector3ToVector3', nodecl> end
-function Quaternion.FromVector3ToVector3(from: Vector3, to: Vector3): Quaternion <cimport'QuaternionFromVector3ToVector3', nodecl> end
+function Raymath.QuaternionFromVector3ToVector3(from: Vector3, to: Vector3): Quaternion <cimport'QuaternionFromVector3ToVector3', cinclude'<raymath.h>', nodecl> end 
+function Quaternion.FromVector3ToVector3(from: Vector3, to: Vector3): Quaternion <cimport'QuaternionFromVector3ToVector3', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Returns a quaternion for a given rotation matrix
-function Raymath.QuaternionFromMatrix(mat: Matrix): Quaternion <cimport'QuaternionFromMatrix', nodecl> end
-function Quaternion.FromMatrix(mat: Matrix): Quaternion <cimport'QuaternionFromMatrix', nodecl> end
+function Raymath.QuaternionFromMatrix(mat: Matrix): Quaternion <cimport'QuaternionFromMatrix', cinclude'<raymath.h>', nodecl> end 
+function Quaternion.FromMatrix(mat: Matrix): Quaternion <cimport'QuaternionFromMatrix', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Returns a matrix for a given quaternion
-function Raymath.QuaternionToMatrix(q: Quaternion): Matrix <cimport'QuaternionToMatrix', nodecl> end
-function Quaternion.ToMatrix(q: Quaternion): Matrix <cimport'QuaternionToMatrix', nodecl> end
+function Raymath.QuaternionToMatrix(q: Quaternion): Matrix <cimport'QuaternionToMatrix', cinclude'<raymath.h>', nodecl> end 
+function Quaternion.ToMatrix(q: Quaternion): Matrix <cimport'QuaternionToMatrix', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Returns rotation quaternion for an angle and axis
 -- NOTE: angle must be provided in radians
-function Raymath.QuaternionFromAxisAngle(axis: Vector3, angle: float32): Quaternion <cimport'QuaternionFromAxisAngle', nodecl> end
-function Quaternion.FromAxisAngle(axis: Vector3, angle: float32): Quaternion <cimport'QuaternionFromAxisAngle', nodecl> end
+function Raymath.QuaternionFromAxisAngle(axis: Vector3, angle: float32): Quaternion <cimport'QuaternionFromAxisAngle', cinclude'<raymath.h>', nodecl> end 
+function Quaternion.FromAxisAngle(axis: Vector3, angle: float32): Quaternion <cimport'QuaternionFromAxisAngle', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Returns the rotation angle and axis for a given quaternion
-function Raymath.QuaternionToAxisAngle(q: Quaternion, outAxis: Vector3*, outAngle: float32*): void <cimport'QuaternionToAxisAngle', nodecl> end
-function Quaternion.ToAxisAngle(q: Quaternion, outAxis: Vector3*, outAngle: float32*): void <cimport'QuaternionToAxisAngle', nodecl> end
+function Raymath.QuaternionToAxisAngle(q: Quaternion, outAxis: *Vector3, outAngle: *float32): void <cimport'QuaternionToAxisAngle', cinclude'<raymath.h>', nodecl> end 
+function Quaternion.ToAxisAngle(q: Quaternion, outAxis: *Vector3, outAngle: *float32): void <cimport'QuaternionToAxisAngle', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Returns he quaternion equivalent to Euler angles
-function Raymath.QuaternionFromEuler(roll: float32, pitch: float32, yaw: float32): Quaternion <cimport'QuaternionFromEuler', nodecl> end
-function Quaternion.FromEuler(roll: float32, pitch: float32, yaw: float32): Quaternion <cimport'QuaternionFromEuler', nodecl> end
+function Raymath.QuaternionFromEuler(roll: float32, pitch: float32, yaw: float32): Quaternion <cimport'QuaternionFromEuler', cinclude'<raymath.h>', nodecl> end 
+function Quaternion.FromEuler(roll: float32, pitch: float32, yaw: float32): Quaternion <cimport'QuaternionFromEuler', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Return the Euler angles equivalent to quaternion (roll, pitch, yaw)
 -- NOTE: Angles are returned in a Vector3 struct in degrees
-function Raymath.QuaternionToEuler(q: Quaternion): Vector3 <cimport'QuaternionToEuler', nodecl> end
-function Quaternion.ToEuler(q: Quaternion): Vector3 <cimport'QuaternionToEuler', nodecl> end
+function Raymath.QuaternionToEuler(q: Quaternion): Vector3 <cimport'QuaternionToEuler', cinclude'<raymath.h>', nodecl> end 
+function Quaternion.ToEuler(q: Quaternion): Vector3 <cimport'QuaternionToEuler', cinclude'<raymath.h>', nodecl> end 
+
 
 -- Transform a quaternion given a transformation matrix
-function Raymath.QuaternionTransform(q: Quaternion, mat: Matrix): Quaternion <cimport'QuaternionTransform', nodecl> end
-function Quaternion.Transform(q: Quaternion, mat: Matrix): Quaternion <cimport'QuaternionTransform', nodecl> end
+function Raymath.QuaternionTransform(q: Quaternion, mat: Matrix): Quaternion <cimport'QuaternionTransform', cinclude'<raymath.h>', nodecl> end 
+function Quaternion.Transform(q: Quaternion, mat: Matrix): Quaternion <cimport'QuaternionTransform', cinclude'<raymath.h>', nodecl> end 
+
 
 
 -- [ operator overloading [
@@ -1744,14 +1919,20 @@ function Vector2.__len(v: Vector2): float32 <cimport'Vector2Length', nodecl> end
 -- Negate vector
 function Vector2.__unm(v: Vector2): Vector2 <cimport'Vector2Negate', nodecl> end
 -- Divide vector by a float value or vector
-function Vector2.__div(v: Vector2, divisor: #[concept(function(d) return d.type.is_arithmetic or d.type.is_vector2 end)]#): Vector2
-  ## local fn_name = divisor.type.is_arithmetic and 'Divide' or 'DivideV'
-  return Vector2.#|fn_name|#(v, divisor)
+function Vector2.__div(v: Vector2, divisor: overload(Vector2, number)): Vector2
+  ## if divisor.type.is_vector2 then
+    return Vector2.DivideV(v, divisor)
+  ## else
+    return Vector2.Divide(v, divisor)
+  ## end
 end
 -- Scale vector (multiply by value) or Multiply vector by vector
-function Vector2.__mul(v: Vector2, multiplier: #[concept(function(m) return m.type.is_arithmetic or m.type.is_vector2 end)]#)
-  ## local fn_name = multiplier.type.is_arithmetic and 'Scale' or 'MultiplyV'
-  return Vector2.#|fn_name|#(v, multiplier)
+function Vector2.__mul(v: Vector2, multiplier: overload(Vector2, number)): Vector2
+  ## if multiplier.type.is_vector2 then
+    return Vector2.MultiplyV(v, multiplier)
+  ## else
+    return Vector2.Scale(v, multiplier)
+  ## end
 end
 -- ] Vector2 ]
 
@@ -1765,14 +1946,20 @@ function Vector3.__len(v: Vector3): float32 <cimport'Vector3Length', nodecl> end
 -- Negate provided vector (invert direction)
 function Vector3.__unm(v: Vector3): Vector3 <cimport'Vector3Negate', nodecl> end
 -- Multiply vector by scalar or by vector
-function Vector3.__mul(v: Vector3, multiplier: #[concept(function(m) return m.type.is_arithmetic or m.type.is_vector3 end)]#)
-  ## local fn_name = multiplier.type.is_arithmetic and 'Scale' or 'Multiply'
-  return Vector3.#|fn_name|#(v, multiplier)
+function Vector3.__mul(v: Vector3, multiplier: overload(Vector3, number)): Vector3
+  ## if multiplier.type.is_vector3 then
+    return Vector3.MultiplyV(v, multiplier)
+  ## else
+    return Vector3.Scale(v, multiplier)
+  ## end
 end
 -- Divide vector by a float value or by vector
-function Vector3.__div(v: Vector3, divisor: #[concept(function(d) return d.type.is_arithmetic or d.type.is_vector3 end)]#)
-  ## local fn_name = divisor.type.is_arithmetic and 'Divide' or 'DivideV'
-  return Vector3.#|fn_name|#(v, divisor)
+function Vector3.__div(v: Vector3, divisor: overload(Vector3, number)): Vector3
+   ## if divisor.type.is_vector3 then
+    return Vector3.DivideV(v, divisor)
+  ## else
+    return Vector3.Divide(v, divisor)
+  ## end
 end
 -- ] Vector3 ]
 

--- a/rotor-quick/makers.nelua
+++ b/rotor-quick/makers.nelua
@@ -71,7 +71,7 @@ global nprof: NProf = {}
       end
    ## end
 
-   function new_entity.new(entity_storage: Storage(Entity)*, values: VlCollection): (new_entity, Entity*)
+   function new_entity.new(entity_storage: *Storage(Entity), values: VlCollection): (new_entity, *Entity)
       local result: new_entity = {}
 
       local entity_id, entity = entity_storage:new_entry(Entity.new())
@@ -133,7 +133,7 @@ global System = @record{
    local storagesCollectionT = @record{}
 
    ## for i, name in ipairs(component_names) do
-      local opt_T = @optional(#[ component_types[i] ]#*)
+      local opt_T = @optional(*#[ component_types[i] ]#)
       ## optCollectionT.value:add_field(name, opt_T.value)
 
       local stor_T = @pointer(Storage( #[ component_types[i] ]# ))

--- a/rotor-quick/systems.nelua
+++ b/rotor-quick/systems.nelua
@@ -115,7 +115,7 @@ global AnimationRunner = @record{}
 function AnimationRunner:run(animations: *Animations, sprite: *Sprite, system_data: *SystemData)
    if not animations.paused then
       animations.elapsed_time = animations.elapsed_time + Globals.dt
-      local current_animation: AnimationData* = animations.animations[animations.current_animation_index]
+      local current_animation: *AnimationData = animations.animations[animations.current_animation_index]
 
       if animations.elapsed_time > current_animation.frame_duration then
          animations.current_frame_index = (animations.current_frame_index + 1) % #current_animation.frame_indexes
@@ -201,7 +201,7 @@ global ShowObstaclesSystem = @MakeSystem(ShowObstaclesRunner, false, true, false
 
 global CollisionDetectionRunner = @record{}
 
-local function is_past_collision(intersections: vector(Intersection)*, entity_id: GenerationalIndex): integer
+local function is_past_collision(intersections: *vector(Intersection), entity_id: GenerationalIndex): integer
    for i = 0, < #intersections do
       if intersections[i].collider.entity_id == entity_id then
          return i


### PR DESCRIPTION
I'm about to remove the deprecated old syntax for pointers/arrays from the Nelua compiler, this fixes remaining compile errors in the project due to use of the old syntax.
I usually use this project as a big "test suite" before pushing anything to Nelua, so I will keep it fixing compile errors now and then when Nelua changes.